### PR TITLE
Options in debian/configure, set package version and create sources.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,4 +2,4 @@ machinekit-hal (0.1) jessie; urgency=low
 
   * Initial packageReworked debian/configure, #215
 
- -- ArcEye <arceye@mgware.co.uk>  Thurs, 16 March 2017 17:30:30 -0000
+ -- ArcEye <arceye@mgware.co.uk>  Thu, 16 Mar 2017 17:30:30 -0000

--- a/debian/configure
+++ b/debian/configure
@@ -63,6 +63,45 @@ do_xenomai() {
     HAVE_FLAVOR=true
 }
 
+## Set version for packages by altering changelog
+## Write new version info then prepend existing one, for use in changes file
+## Allows command line builds and builds outside of Travis environment to set meaningful version numbers
+
+do_changelog() {
+    DISTRO_UC="$(lsb_release -c | cut -c 10- | sed 's/^[[:space:]]*//g' | sed -e 's/\b\(.\)/\u\1/g')"
+    DISTRO_LC="$(lsb_release -c | cut -c 10- | sed 's/^[[:space:]]*//g')"
+    MKVERSION="$(git show HEAD:VERSION | cut -d ' ' -f 1).$(git rev-list --count master)-1.git$(git rev-parse --short HEAD)~${DISTRO_LC}"
+    COMMITTER="$(git show -s --pretty=%an $(git rev-parse --short HEAD))"
+    EMAIL="$(git show -s --format='%ae' $(git rev-parse --short HEAD))"
+
+    mv changelog changelog.old
+    cat > changelog <<EOF
+machinekit-hal (${MKVERSION}) ${DISTRO_UC}; urgency=low
+
+  * Cross-Builder rebuild for Debian ${DISTRO_UC}, commit $(git rev-parse --short HEAD)
+
+ -- ${COMMITTER} <${EMAIL}>  $(date -R)
+
+EOF
+
+cat changelog # debug output
+cat changelog.old >> changelog
+echo "New package version number added to changelog"
+}
+
+## Create source orig tarball in format required for creation of debian tarball and .dsc file
+## Allows non binary package builds from command line or outside Travis environment
+
+do_source_tarball() {
+#version based on major version plus commit number only, without suffixed -1 or commit hash
+MK_VERSION="$(git show HEAD:VERSION | cut -d ' ' -f 1).$(git rev-list --count master)"
+
+OWD=$PWD
+cd ../
+git archive HEAD | bzip2 -z > ../machinekit-hal_${MK_VERSION}.orig.tar.bz2
+echo "Source tarball created"
+cd $OWD
+}
 
 usage() {
     {
@@ -72,6 +111,11 @@ usage() {
 	echo "   -p		build POSIX threads"
 	echo "   -r		build RT_PREEMPT threads"
 	echo "   -x		build Xenomai threads"
+	echo "   -c		rewrite changelog to set package version from git commit"
+	echo "	 -s		create source tarball for non binary package builds"
+	echo "   -X <kver>	build Xenomai-kernel threads ***"
+	echo "   -R <kver>	build RTAI-kernel threads ***"
+	echo "   -t <tclver>	set tcl/tk version"
 	echo "      *** Argument may be repeated for multiple kernels"
     } >&2
     exit 1
@@ -104,12 +148,16 @@ echo "debian/rules:  copied base template" >&2
 #cp machinekit-hal-posix.install.in machinekit-hal-posix.install
 #echo "debian/machinekit-hal-posix.install.in:  copied base template" >&2
 
-# read command line options
-while getopts prx:?h ARG; do
+while getopts dprxcsR:X:t:?h ARG; do
     case $ARG in
 	p) do_posix ;;
 	r) do_rt-preempt ;;
 	x) do_xenomai ;;
+	c) do_changelog ;;  # set new changelog with package versions from git
+	s) do_source_tarball ;; # create tarball for non binary builds
+	R) do_rtai_kernel "$OPTARG" ;;
+	X) do_xenomai_kernel "$OPTARG" ;;
+	t) TCL_TK_VER="$OPTARG" ;;
 	?|h) usage ;;
 	*) usage "Unknown arg: '-$ARG'" ;;
     esac


### PR DESCRIPTION
Currently package version is set by Travis writing a debian/changelog entry
setting the version from vars inside Travis prepended onto the existing changelog.

If building manually or via a different CI system, this patch gives the option of calling
`debian/configure -c <other args>`, which will create a changelog entry with a version derived from
 information within git and the running system.

The version will be derived from
`<machinekit-hal main version>.<number of commits>-1.git<SHA>~<distro>`

Option also included `debian/configure -s <other args>` to create sources.
.orig tarball created with a version format which will allow creation of .debian tarball and .dsc file,
when doing package build from command line or otherwise outside Travis environment

Has no effect upon existing builds, which will not use it.
In preparation for alternative build system.

Signed-off-by: Mick <arceye@mgware.co.uk>