### PR TITLE
Have debian/configure differentiate Stretch builds

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -6,7 +6,11 @@
 
 # List of supported kernel arches for kthreads
 KTHREAD_ARCHES="i386 amd64"
-
+if test -x /usr/bin/lsb_release; then
+    DISTRO_ID=$(lsb_release -is)  # Debian or Ubuntu
+    DISTRO_RELEASE=$(lsb_release -rs)   # 8.1, 14.04, etc.
+    DISTRO_CODENAME=$(lsb_release -cs) # wheezy | jessie | stretch
+fi
 
 # Work out of the debian/ directory
 cd "$(dirname $0)"
@@ -45,12 +49,20 @@ do_posix() {
     HAVE_FLAVOR=true
 }
 
+## cater for fact that Stretch now has it's own rt-preempt kernels
 do_rt-preempt() {
-    cat control.rt-preempt.in >> control
-    echo "debian/control:  added RT_PREEMPT threads package" >&2
+    if [[ $DISTRO_CODENAME == "stretch" ]] ; then
+	cat control.rt-preempt-stretch.in >> control
+	echo "debian/control:  added RT_PREEMPT threads package for Stretch" >&2
+    else
+	cat control.rt-preempt.in >> control
+	echo "debian/control:  added RT_PREEMPT threads package for Wheezy/Jessie" >&2
+    fi
+
     rules_enable_threads rt-preempt
     HAVE_FLAVOR=true
 }
+
 
 do_xenomai() {
     # Be sure the -dev files only appear once
@@ -68,8 +80,8 @@ do_xenomai() {
 ## Allows command line builds and builds outside of Travis environment to set meaningful version numbers
 
 do_changelog() {
-    DISTRO_UC="$(lsb_release -c | cut -c 10- | sed 's/^[[:space:]]*//g' | sed -e 's/\b\(.\)/\u\1/g')"
-    DISTRO_LC="$(lsb_release -c | cut -c 10- | sed 's/^[[:space:]]*//g')"
+    DISTRO_UC="$(echo $DISTRO_CODENAME | sed 's/^[[:space:]]*//g' | sed -e 's/\b\(.\)/\u\1/g')"
+    DISTRO_LC="$(echo $DISTRO_CODENAME | sed 's/^[[:space:]]*//g')"
     MKVERSION="$(git show HEAD:VERSION | cut -d ' ' -f 1).$(git rev-list --count master)-1.git$(git rev-parse --short HEAD)~${DISTRO_LC}"
     COMMITTER="$(git show -s --pretty=%an $(git rev-parse --short HEAD))"
     EMAIL="$(git show -s --format='%ae' $(git rev-parse --short HEAD))"

--- a/debian/control.rt-preempt-stretch.in
+++ b/debian/control.rt-preempt-stretch.in
@@ -1,0 +1,13 @@
+
+Package: machinekit-hal-rt-preempt
+Architecture: any
+Provides:  machinekit-hal
+Conflicts: machinekit
+Depends: ${misc:Depends},
+    python-numpy, python-vte, python-xlib, python-configobj,
+    python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
+    python-avahi, bc, procps, psmisc, module-init-tools | kmod,
+    linux-image-rt-686-pae [i386], linux-image-rt-amd64 [amd64]
+Description: HAL stack split from machinekit
+ .
+ This package provides components and drivers that run on an RT-Preempt system.


### PR DESCRIPTION
The control-rt-preempt.in file specifies a particular rt-preempt kernel
in the deb.machinekit.io repo
This was because Jessie dropped rt-preempt support creating unmet
dependencies.

Stretch now supports rt-preempt, so debian/configure specifies a generic
`linux-image-rt [amd64|i386]` dependency, which Debian can meet.

Also simplify further the parsing routines to generate package serial

Signed-off-by: Mick <arceye@mgware.co.uk>