### PR TITLE
Dependency changes for Stretch packaging

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -43,8 +43,13 @@ guess_arch_from_kver() {
 }
 
 do_posix() {
-    cat control.posix.in >> control
-    echo "debian/control:  added POSIX threads package" >&2
+    if [[ $DISTRO_CODENAME == "stretch" ]] ; then
+	cat control.posix-stretch.in >> control
+	echo "debian/control:  added POSIX threads package for stretch" >&2
+    else
+	cat control.posix.in >> control
+        echo "debian/control:  added POSIX threads package" >&2
+    fi
     rules_enable_threads posix
     HAVE_FLAVOR=true
 }
@@ -153,8 +158,15 @@ HAVE_KTHREADS_FLAVOR=false
 rm -f machinekit-hal-{rtai,xenomai}-kernel-*.install
 
 # copy base templates into place
-cp control.in control
+# stretch uses some different packages
+if [[ $DISTRO_CODENAME == "stretch" ]] ; then
+    cp control-stretch.in control
+    echo "debian/control:  copied Stretch base template" >&2
+else
+    cp control.in control
 echo "debian/control:  copied base template" >&2
+fi
+
 cp rules.in rules; chmod +x rules
 echo "debian/rules:  copied base template" >&2
 #cp machinekit-hal-posix.install.in machinekit-hal-posix.install

--- a/debian/control-stretch.in
+++ b/debian/control-stretch.in
@@ -1,0 +1,20 @@
+Source: machinekit-hal
+Section: misc
+Priority: extra
+Maintainer: ArcEye <arceyeATmgwareDOTcoDOTuk>
+Build-Depends: debhelper (>= 6),
+    autoconf (>= 2.63), automake, libboost-python-dev, libgl1-mesa-dev,
+    libglu1-mesa-dev, libmodbus-dev (>= 3.0),
+    libncurses-dev, libreadline-dev, libusb-1.0-0-dev, libxmu-dev,
+    libxmu-headers, python (>= 2.6.6-3~), python-dev (>= 2.6.6-3~),
+    cython (>= 0.19), dh-python,
+    pkg-config, psmisc, libxaw7-dev, libboost-serialization-dev,
+    zeromq, czmq, libjansson-dev (>= 2.5),
+    procps, kmod,
+    liburiparser-dev, libssl-dev, python-setuptools,
+    uuid-dev, uuid-runtime, libavahi-client-dev,
+    libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
+    python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
+    python-simplejson, libboost-thread-dev,
+    python-pyftpdlib, @BUILD_DEPS@
+Standards-Version: 2.1.0

--- a/debian/control.posix-stretch.in
+++ b/debian/control.posix-stretch.in
@@ -1,0 +1,13 @@
+
+Package: machinekit-hal-posix
+Architecture: any
+Provides:  machinekit-hal
+Conflicts: machinekit
+Depends: ${misc:Depends},
+    python-numpy, python-vte, python-xlib, python-configobj,
+    czmq, zeromq, python-protobuf (>= 2.4.1), python-gst-1.0,
+    python-avahi, bc, procps, psmisc, module-init-tools | kmod
+Description: HAL stack split from Machinekit
+ .
+ This package provides components and drivers that run on a non-realtime
+ (Posix) system.

--- a/debian/control.rt-preempt-stretch.in
+++ b/debian/control.rt-preempt-stretch.in
@@ -5,7 +5,7 @@ Provides:  machinekit-hal
 Conflicts: machinekit
 Depends: ${misc:Depends},
     python-numpy, python-vte, python-xlib, python-configobj,
-    python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
+    zeromq, czmq, python-protobuf (>= 2.4.1), python-gst-1.0,
     python-avahi, bc, procps, psmisc, module-init-tools | kmod,
     linux-image-rt-686-pae [i386], linux-image-rt-amd64 [amd64]
 Description: HAL stack split from machinekit

--- a/debian/extras/etc/ld.so.conf.d/czmq-zeromq.conf
+++ b/debian/extras/etc/ld.so.conf.d/czmq-zeromq.conf
@@ -1,0 +1,2 @@
+# Ensure temp czmq and zeromq libs are found
+/usr/local/lib

--- a/debian/machinekit-hal-posix.install
+++ b/debian/machinekit-hal-posix.install
@@ -2,6 +2,7 @@ etc/linuxcnc/*
 etc/rsyslog.d/linuxcnc.conf
 etc/security/limits.d/machinekit.conf
 etc/udev/rules.d/50-shmdrv.rules
+etc/ld.so.conf.d/czmq-zeromq.conf
 usr/lib/*.so.*
 usr/bin/*
 usr/lib/python*/*/*.py
@@ -27,3 +28,4 @@ usr/share/linuxcnc/*.gif
 usr/share/linuxcnc/*.png
 usr/share/linuxcnc/Makefile.*
 usr/share/linuxcnc/udev/90-xhc.rules
+

--- a/debian/machinekit-hal-rt-preempt.install
+++ b/debian/machinekit-hal-rt-preempt.install
@@ -2,6 +2,7 @@ etc/linuxcnc/*
 etc/rsyslog.d/linuxcnc.conf
 etc/security/limits.d/machinekit.conf
 etc/udev/rules.d/50-shmdrv.rules
+etc/ld.so.conf.d/czmq-zeromq.conf
 usr/lib/*.so.*
 usr/bin/*
 usr/lib/python*/*/*.py


### PR DESCRIPTION
    Depended package has changed numbering
    ie. python-gst0.1 becomes python-gst-1.0
        
    python-zmq depends upon later versions of zmq (libzmq5) so cannot be a dep.

    Specify czmq and zeromq to bring in the libs built which use the
    previous API.
    Add an /etc/ld.so.conf.d/ entry to ensure it caches /usr/local/lib

    configure detects distro codename and makes substitutions if
    Stretch detected - so will not affect existing builds

Signed-off-by: Mick <arceye@mgware.co.uk>