### PR TITLE
Merge branch 'update-build-debs' into Machinekit-HAL master

### DIFF
--- a/.jenkins/build-manpages.sh
+++ b/.jenkins/build-manpages.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-cd /work/src
-rm -rf ../man/man9/*.asciidoc || /bin/true
-sh autogen.sh
-./configure --enable-build-documentation
-make docpages i_docpages
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,28 +30,19 @@ env:
     - SFTP_USER="${SFTP_USER:-travis}"
     - SFTP_ADDR="${SFTP_ADDR:-empty}"
   matrix:
-    - TAG=wheezy-64    CMD=run_tests
     - TAG=jessie-64    CMD=run_tests
-    - TAG=wheezy-64    CMD=build_deb
-    - TAG=wheezy-32    CMD=build_deb
-    - TAG=wheezy-armhf CMD=build_deb FLAV=posix
-    - TAG=wheezy-armhf CMD=build_deb FLAV=xenomai
-    - TAG=wheezy-armhf CMD=build_deb FLAV=rt_preempt
     - TAG=jessie-64    CMD=build_deb
     - TAG=jessie-32    CMD=build_deb
     - TAG=jessie-armhf CMD=build_deb FLAV=posix
     - TAG=jessie-armhf CMD=build_deb FLAV=xenomai
     - TAG=jessie-armhf CMD=build_deb FLAV=rt_preempt
-    - TAG=raspbian-armhf CMD=build_deb FLAV=posix
-    - TAG=raspbian-armhf CMD=build_deb FLAV=xenomai
-    - TAG=raspbian-armhf CMD=build_deb FLAV=rt_preempt
 
 script:
   - .travis/docker_run.sh
 
 after_success:
   - .travis/send_binaries.sh
-  - test ${TAG} != "raspbian-armhf" && .travis/upload_packagecloud.sh
+  - .travis/upload_packagecloud.sh
 
 after_script:
   - .travis/send_status.sh

--- a/.travis/build_deb.sh
+++ b/.travis/build_deb.sh
@@ -12,7 +12,7 @@ fi
 MAJOR_MINOR_VERSION="${MAJOR_MINOR_VERSION:-0.1}"
 PKGSOURCE="${PKGSOURCE:-travis.${TRAVIS_REPO_SLUG/\//.}}"
 DEBIAN_SUITE="${DEBIAN_SUITE:-experimental}"
-REPO_URL="${REPO_URL:-https://github.com/machinekit/machinekit}"
+REPO_URL="${REPO_URL:-https://github.com/arceye/Machinekit-HAL}"
 
 # Compute version
 if ${IS_PR}; then
@@ -45,7 +45,7 @@ RELEASE="1${UPSTREAM}.git${SHA1SHORT}~1${DISTRO}"
 # https://www.debian.org/doc/debian-policy/ch-source.html#s-dpkgchangelog
 mv debian/changelog debian/changelog.old
 cat > debian/changelog <<EOF
-machinekit (${VERSION}-${RELEASE}) ${DEBIAN_SUITE}; urgency=low
+machinekit-hal (${VERSION}-${RELEASE}) ${DEBIAN_SUITE}; urgency=low
 
   * Travis CI rebuild for ${DISTRO}, ${PR_OR_BRANCH}, commit ${SHA1SHORT}
     - ${COMMIT_URL}
@@ -63,7 +63,7 @@ if test ${MARCH} = 64; then
     (
 	cd ${ROOTFS}${MACHINEKIT_PATH}
 	git archive HEAD | bzip2 -z > \
-            ../machinekit_${VERSION}.orig.tar.bz2
+            ../machinekit-hal_${VERSION}.orig.tar.bz2
     )
 else
     # the rest will be binaries only

--- a/.travis/check_sftp.sh
+++ b/.travis/check_sftp.sh
@@ -33,9 +33,13 @@ cd shared/info
 put ${TRAVIS_BUILD_DIR}/../${FILE}
 bye
 EOF
+    chmod 700 ~/.ssh/
+    chmod 600 ~/.ssh/*
+    chown -R $USER ~/.ssh/
+    chgrp -R $USER ~/.ssh/
 
     err=0
-    sshpass -p ${SFTP_PASSWD} sftp -P ${SFTP_PORT} -o StrictHostKeyChecking=no \
+    sshpass -p ${SFTP_PASSWD} sftp -v -P ${SFTP_PORT} -o StrictHostKeyChecking=no \
         -oBatchMode=no -b ${TRAVIS_BUILD_DIR}/../sftp_cmds \
         ${SFTP_USER}@${SFTP_ADDR} || err=$?
 

--- a/.travis/docker_run.sh
+++ b/.travis/docker_run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 cd "$(dirname $0)/.."
 
-MACHINEKIT_PATH="/usr/src/machinekit"
+MACHINEKIT_PATH="/usr/src/Machinekit-HAL"
 TRAVIS_PATH="$MACHINEKIT_PATH/.travis"
 DOCKER_CONTAINER=${DOCKER_CONTAINER:-"machinekit/mk-builder"}
 COMMITTER_NAME="$(git log -1 --pretty=format:%an)"

--- a/.travis/save_ccache.sh
+++ b/.travis/save_ccache.sh
@@ -6,14 +6,14 @@ if [ ! -z ${FLAV+x} ]; then
 fi
 
 # only upload if ssh key is present
-if [ -f ~/.ssh/id_rsa ]; then
-    cd ${TRAVIS_BUILD_DIR}/../ccache
-    git init
-    git add -A
-    git config --global user.email "travis-ci@machinekit.io"
-    git config --global user.name "travis-ci"
-    git commit -m ccache 2>&1 >/dev/null
-    git remote add origin git@github.com:${CCACHE_REPO}.git
-    git checkout -b ${branch}
-    git push --set-upstream origin ${branch} --force || true
-fi
+#if [ -f ~/.ssh/id_rsa ]; then
+#    cd ${TRAVIS_BUILD_DIR}/../ccache
+#    git init
+#    git add -A
+#    git config --global user.email "travis-ci@machinekit.io"
+#    git config --global user.name "travis-ci"
+#    git commit -m ccache 2>&1 >/dev/null
+#    git remote add origin git@github.com:${CCACHE_REPO}.git
+#    git checkout -b ${branch}
+#    git push --set-upstream origin ${branch} --force || true
+#fi

--- a/.travis/upload_packagecloud.sh
+++ b/.travis/upload_packagecloud.sh
@@ -25,7 +25,6 @@ if [ "${TRAVIS_TEST_RESULT}" -eq 0 ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] \
     # have already been uploaded
     if [ "${FLAV}" == "rt_preempt" ] || [ "${FLAV}" == "xenomai" ]; then
         rm -f ${TRAVIS_BUILD_DIR}/deploy/machinekit_*
-        rm -f ${TRAVIS_BUILD_DIR}/deploy/machinekit-dev*
     fi
 
     package_cloud push ${repo} ${TRAVIS_BUILD_DIR}/deploy/*deb

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,4 +1,5 @@
 /*
 !/machinekit
 !/profile_axis
+!/mank
 !/.gitignore

--- a/debian/configure
+++ b/debian/configure
@@ -68,6 +68,24 @@ do_rt-preempt() {
     HAVE_FLAVOR=true
 }
 
+do_tcl_tk_version() {
+    TCL_TK_VER="$1"
+    if test -z "$TCL_TK_VER"; then
+        # No -t option specified; to ensure a reproducible package,
+        # use the latest version from the distro
+	TCL_TK_VER=8.6
+	case "$DISTRO_ID" in
+	    Debian)  test "${DISTRO_RELEASE/.*/}" -lt 8 && TCL_TK_VER=8.5 ;;
+	    Raspbian)test "${DISTRO_RELEASE/.*/}" -lt 8 && TCL_TK_VER=8.5 ;;
+	    Ubuntu)  test "${DISTRO_RELEASE/.*/}" -lt 14 && TCL_TK_VER=8.5 ;;
+	    neon)  test "${DISTRO_RELEASE/.*/}" -lt 14 && TCL_TK_VER=8.5 ;;
+	    *)  usage "Unknown distro '${DISTRO_ID}'" ;;
+	esac
+    fi
+    TCL_TK_BUILD_DEPS="tcl${TCL_TK_VER}-dev, tk${TCL_TK_VER}-dev"
+    TCL_TK_DEPS="tcl${TCL_TK_VER}, tk${TCL_TK_VER}"
+    echo "debian/control:  Set tcl/tk build deps to version $TCL_TK_VER" >&2
+}
 
 do_xenomai() {
     # Be sure the -dev files only appear once
@@ -130,8 +148,6 @@ usage() {
 	echo "   -x		build Xenomai threads"
 	echo "   -c		rewrite changelog to set package version from git commit"
 	echo "	 -s		create source tarball for non binary package builds"
-	echo "   -X <kver>	build Xenomai-kernel threads ***"
-	echo "   -R <kver>	build RTAI-kernel threads ***"
 	echo "   -t <tclver>	set tcl/tk version"
 	echo "      *** Argument may be repeated for multiple kernels"
     } >&2
@@ -154,6 +170,10 @@ DEPS= # List of Depends
 HAVE_FLAVOR=false
 HAVE_KTHREADS_FLAVOR=false
 
+# Determine tcl/tk version
+do_tcl_tk_version "$TCL_TK_VER"
+
+
 # delete old files
 rm -f machinekit-hal-{rtai,xenomai}-kernel-*.install
 
@@ -172,15 +192,14 @@ echo "debian/rules:  copied base template" >&2
 #cp machinekit-hal-posix.install.in machinekit-hal-posix.install
 #echo "debian/machinekit-hal-posix.install.in:  copied base template" >&2
 
-while getopts dprxcsR:X:t:?h ARG; do
+# read command line options - d is a dummy to stop args being req
+while getopts prxd:t:?h ARG; do
     case $ARG in
 	p) do_posix ;;
 	r) do_rt-preempt ;;
 	x) do_xenomai ;;
 	c) do_changelog ;;  # set new changelog with package versions from git
 	s) do_source_tarball ;; # create tarball for non binary builds
-	R) do_rtai_kernel "$OPTARG" ;;
-	X) do_xenomai_kernel "$OPTARG" ;;
 	t) TCL_TK_VER="$OPTARG" ;;
 	?|h) usage ;;
 	*) usage "Unknown arg: '-$ARG'" ;;

--- a/debian/control.xenomai.in
+++ b/debian/control.xenomai.in
@@ -1,11 +1,10 @@
 
 Package: machinekit-hal-xenomai
 Architecture: any
-Depends: xenomai-runtime
 Provides:  machinekit-hal
 Conflicts: machinekit
 Depends: ${misc:Depends},
-    python-numpy, python-vte, python-xlib, python-configobj,
+    xenomai-runtime, python-numpy, python-vte, python-xlib, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
     python-avahi, bc, procps, psmisc, module-init-tools | kmod
 Description: HAL stack split from machinekit

--- a/debian/machinekit-hal-posix.install.in
+++ b/debian/machinekit-hal-posix.install.in
@@ -11,7 +11,7 @@ usr/lib/python*/*/*/*.py
 usr/lib/python*/*/machinetalk/protobuf/*.py
 usr/lib/python*/*/machinetalk/*.py
 usr/lib/python*/*/machinekit/nosetests/*.py
-usr/lib/linuxcnc/rt-preempt/*.so
+usr/lib/linuxcnc/posix/*.so
 usr/include/linuxcnc/*.h
 usr/include/linuxcnc/*.hh
 usr/libexec/linuxcnc/pci_read
@@ -19,11 +19,10 @@ usr/libexec/linuxcnc/pci_write
 usr/libexec/linuxcnc/inivar
 usr/libexec/linuxcnc/flavor
 usr/libexec/linuxcnc/rtapi_msgd
-usr/libexec/linuxcnc/rtapi_app_rt-preempt
+usr/libexec/linuxcnc/rtapi_app_posix
 etc/modprobe.d/linuxcnc.conf
 usr/lib/*.so
-usr/lib/linuxcnc/ulapi-rt-preempt.so
-usr/include/linuxcnc/userpci/*.h
+usr/lib/linuxcnc/ulapi-posix.so
 usr/share/linuxcnc/*.gif
 usr/share/linuxcnc/*.png
 usr/share/linuxcnc/Makefile.*

--- a/debian/machinekit-hal-rt-preempt.install.in
+++ b/debian/machinekit-hal-rt-preempt.install.in
@@ -11,7 +11,7 @@ usr/lib/python*/*/*/*.py
 usr/lib/python*/*/machinetalk/protobuf/*.py
 usr/lib/python*/*/machinetalk/*.py
 usr/lib/python*/*/machinekit/nosetests/*.py
-usr/lib/linuxcnc/posix/*.so
+usr/lib/linuxcnc/rt-preempt/*.so
 usr/include/linuxcnc/*.h
 usr/include/linuxcnc/*.hh
 usr/libexec/linuxcnc/pci_read
@@ -19,13 +19,11 @@ usr/libexec/linuxcnc/pci_write
 usr/libexec/linuxcnc/inivar
 usr/libexec/linuxcnc/flavor
 usr/libexec/linuxcnc/rtapi_msgd
-usr/libexec/linuxcnc/rtapi_app_posix
+usr/libexec/linuxcnc/rtapi_app_rt-preempt
 etc/modprobe.d/linuxcnc.conf
 usr/lib/*.so
-usr/lib/linuxcnc/ulapi-posix.so
-usr/include/linuxcnc/userpci/*.h
+usr/lib/linuxcnc/ulapi-rt-preempt.so
 usr/share/linuxcnc/*.gif
 usr/share/linuxcnc/*.png
 usr/share/linuxcnc/Makefile.*
 usr/share/linuxcnc/udev/90-xhc.rules
-

--- a/debian/machinekit-hal-xenomai.install.in
+++ b/debian/machinekit-hal-xenomai.install.in
@@ -10,7 +10,7 @@ usr/lib/python*/*/*/*.py
 usr/lib/python*/*/machinetalk/protobuf/*.py
 usr/lib/python*/*/machinetalk/*.py
 usr/lib/python*/*/machinekit/nosetests/*.py
-usr/lib/linuxcnc/xenomai/*.so
+usr/lib/linuxcnc/xenomai/*
 usr/include/linuxcnc/*.h
 usr/include/linuxcnc/*.hh
 usr/libexec/linuxcnc/pci_read
@@ -22,7 +22,6 @@ usr/libexec/linuxcnc/rtapi_app_xenomai
 etc/modprobe.d/linuxcnc.conf
 usr/lib/*.so
 usr/lib/linuxcnc/ulapi-xenomai.so
-usr/include/linuxcnc/userpci/*.h
 usr/share/linuxcnc/*.gif
 usr/share/linuxcnc/*.png
 usr/share/linuxcnc/Makefile.*

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -122,7 +122,20 @@ endif
 #	# Remove package artifacts
 	dh_clean
 
+
 install: build
+
+	## have to test after build or Makefile.inc will not exist ##
+	cp debian/machinekit-hal-posix.install.in debian/machinekit-hal-posix.install
+	cp debian/machinekit-hal-rt-preempt.install.in debian/machinekit-hal-rt-preempt.install
+	cp debian/machinekit-hal-xenomai.install.in debian/machinekit-hal-xenomai.install
+
+	if (grep ^USERMODE_PCI=yes src/Makefile.inc -q); then \
+	    echo "usr/include/linuxcnc/userpci/*.h" >> debian/machinekit-hal-posix.install; \
+	    echo "usr/include/linuxcnc/userpci/*.h" >> debian/machinekit-hal-rt-preempt.install; \
+	    echo "usr/include/linuxcnc/userpci/*.h" >> debian/machinekit-hal-xenomai.install; \
+	fi
+
 	dh_testdir
 	dh_testroot
 	dh_prep
@@ -165,7 +178,7 @@ binary-arch: build install
 	dh_fixperms -X/linuxcnc_module_helper -X/rtapi_app_
 	dh_python2 --ignore-shebangs --no-guessing-versions
 	dh_installdeb
-	### Needed whilst using our own libs which may not have full debian info and deps
+	### Needed whilst usin our own libs which may not have full debian info and deps
 	#dh_shlibdeps -l debian/machinekit-hal/usr/lib
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info -l debian/machinekit-hal/usr/lib
 	dh_gencontrol

--- a/scripts/build_docker
+++ b/scripts/build_docker
@@ -1,0 +1,163 @@
+#!/bin/bash -e
+#
+# Build/cross-build Machinekit-HAL in Docker
+#
+# This script can be run manually or in Travis CI.  Sample manual
+# usage, `$PWD` is the `src/` directory:
+#
+# .travis/docker_build.sh
+
+###########################################################
+# Configuration from environment, CL args and defaults
+CMD=${CMD:-shell}
+IMAGE=${IMAGE:-dovetailautomata/mk-cross-builder}
+TAG=${TAG:-amd64}
+JOBS=${JOBS:-2}
+BUILD_SOURCE=${BUILD_SOURCE:-true}  # update Changelog & source pkg
+
+# CL arguments
+while getopts c:i:t:j:nh? opt; do
+    case "$opt" in
+	c) CMD=$OPTARG ;;
+	i) IMAGE=$OPTARG ;;
+	t) TAG=$OPTARG ;;
+	j) JOBS=$OPTARG ;;
+	n) BUILD_SOURCE=false ;;
+	?|h|*) echo "Usage:  $0 [ -i DOCKER-IMAGE ] [ -t DOCKER-TAG ]" \
+	    "[ -c ( deb [ -n ] | test | [ shell ] [ COMMAND ARG ... ] ) ]" >&2
+	    exit 1 ;;
+    esac
+done
+shift $(($OPTIND - 1))
+
+###########################################################
+# Set build parameters
+
+case ${TAG} in
+    amd64)
+	BUILD_OPTS='-b'                  # Build all binary packages
+	RUN_TESTS='runtests tests'       # Run tests on build arch
+	;;
+    i386)                                # Machine arch: i386
+	BUILD_OPTS="-a i386"             # - Set machine arch
+	;;&
+    armhf|raspbian)                      # Machine arch: armhf
+	BUILD_OPTS="-a armhf"            # - Set machine arch
+	;;&
+    i386|armhf|raspbian)                 # Cross-compile/foreign arch
+	BUILD_OPTS+=" -B"                # - Only build arch binary packages
+	BUILD_OPTS+=" -d"                # - Root fs missing build deps; force
+	RUN_TESTS='true'                 # - Don't run tests
+	BUILD_SOURCE=false               # - Don't build source package
+	;;
+    *) echo "Warning:  unknown tag '${TAG}'" >&2 ;;
+esac
+
+# DH_VERBOSE turn on verbose package debuilds
+! ${MK_PACKAGE_VERBOSE:-false} || export DH_VERBOSE=1
+
+# Parallel jobs in `make`
+export DEB_BUILD_OPTIONS="parallel=${JOBS}"
+
+# UID/GID to carry into Docker
+DUID=`id -u`; DGID=`id -g`
+
+# Bind source directory:  parent of $PWD for packages
+BIND_SOURCE_DIR="$(readlink -f $PWD/..)"
+
+# Directory containing this script
+SCRIPT_DIR="$(dirname $0)"
+
+# Make TAG accessible to called programs
+export TAG
+
+###########################################################
+# Generate command line
+
+declare -a BUILD_CL DOCKER_EXTRA_OPTS
+case $CMD in
+    "shell"|"") # Interactive shell (default)
+	DOCKER_EXTRA_OPTS=( --privileged )
+	if test -z "$*"; then
+	    BUILD_CL=( bash -i )
+	else
+	    BUILD_CL=( "$@" )
+	fi
+	;;
+    "deb") # Build Debian packages
+	DOCKER_EXTRA_OPTS=(
+	    # Used in dpkg-buildpackage
+	    -e DEB_BUILD_OPTIONS=$DEB_BUILD_OPTIONS
+	    -e DH_VERBOSE=$DH_VERBOSE
+	    # Used in scripts/build_source_package
+	    -e DEBIAN_SUITE=$DEBIAN_SUITE
+	    -e MAJOR_MINOR_VERSION=$MAJOR_MINOR_VERSION
+	    -e PKGSOURCE=$PKGSOURCE
+	    -e REPO_URL=$REPO_URL
+	    -e TRAVIS_BRANCH=$TRAVIS_BRANCH
+	    -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST
+	    -e TRAVIS_REPO=$TRAVIS_REPO
+	    -e TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG
+	)
+	BUILD_CL=( bash -xec "
+            # configure source package
+            debian/configure -prxt 8.6;
+
+            # update Changelog and build source package
+            $SCRIPT_DIR/build_source_package $BUILD_SOURCE
+
+            # build binary packages
+            dpkg-buildpackage -uc -us ${BUILD_OPTS} -j$JOBS
+            "
+	)
+	;;
+    "test") # RIP build and regression tests
+	BUILD_CL=( bash -xec "
+            # Set up build:  \`autoconf\` and \`make\`
+	    cd src;
+	    ./autogen.sh;
+	    ./configure --host=\$HOST_MULTIARCH;
+
+            # Build
+	    make -j${JOBS};
+
+            # Set up runtime:  setuid, environment, ini
+	    sudo make setuid >& /dev/null || true;
+	    cd ..;
+	    . scripts/rip-environment;
+	    echo -e 'ANNOUNCE_IPV4=0\nANNOUNCE_IPV6=0' >> \
+		etc/linuxcnc/machinekit.ini;
+	    tail etc/linuxcnc/machinekit.ini;
+
+            # Run regression tests
+	    ${RUN_TESTS}"
+	)
+	;;
+    *)   echo "Unkown command '$CMD'" >&2; exit 1 ;;
+esac
+
+###########################################################
+# Run build
+
+set -x  # Show user the command
+
+# Run the Docker container as follows:
+# - Remove container after exit
+# - Run interactively with terminal
+# - Add any `DOCKER_EXTRA_OPTS` from above
+# - As Travis CI user/group
+# - Bind-mount home and source directories; start in source directory
+# - Pass environment variable `TAG`
+# - Set hostname to $IMAGE:$TAG (replace `/` and `:` with `-`)
+# - Run build command as set above
+# hide --it
+docker run \
+    --rm \
+    "${DOCKER_EXTRA_OPTS[@]}" \
+    -u $DUID:$DGID -e USER=${USER} \
+    -v ${HOME}:${HOME} -e HOME=${HOME} \
+    -v ${BIND_SOURCE_DIR}:${BIND_SOURCE_DIR} -w ${PWD} \
+    -e TAG=${TAG} \
+    -h ${IMAGE//[\/:]/-}-${TAG} \
+    ${IMAGE}:${TAG} \
+    "${BUILD_CL[@]}"

--- a/scripts/build_packagecloud_upload
+++ b/scripts/build_packagecloud_upload
@@ -1,0 +1,65 @@
+#!/bin/bash -e
+#
+# Upload packages to packagecloud.io
+#
+# In Travis CI, set the following environment variables:
+# - PACKAGECLOUD_USER:  Travis CI user name
+# - PACKAGECLOUD_TOKEN:  ** HIDDEN **  User's Travis CI token
+# - PACKAGECLOUD_REPO:  Same as the GitHub repo
+# - DEPLOY_BRANCH:  Only push build results for this branch
+#
+# The following environment variables should be set in .travis.yml:
+# - CMD:  (Also may be first arg to script) Exit if not 'deb'
+# - TAG:  One of amd64/i386/armhf/raspbian
+#
+# The following environment variables should be set by Travis CI:
+# - TRAVIS_TEST_RESULT:  Exit if not '0'
+# - TRAVIS_PULL_REQUEST:  Exit if not 'false'
+# - TRAVIS_BRANCH:  Exit unless matches DEPLOY_BRANCH
+#
+# The `package_cloud` ruby gem should be installed
+
+TAG=${1:-$TAG}
+
+################################################
+# Checks
+
+exit_nice () { echo "No packagecloud upload:  $*" >&2; exit 0; }
+error () { echo "Error:  $*" >&2; exit 1; }
+
+test -n "PACKAGECLOUD_USER" || \
+    exit_nice "PACKAGECLOUD_USER not set"
+test "$CMD" = "deb" || \
+    exit_nice "CMD '$CMD' != 'deb'"
+test "$TRAVIS_TEST_RESULT" -eq 0 || \
+    exit_nice "TRAVIS_TEST_RESULT '$TRAVIS_TEST_RESULT' != '0'"
+test "$TRAVIS_PULL_REQUEST" = false || \
+    exit_nice "TRAVIS_PULL_REQUEST '$TRAVIS_PULL_REQUEST' != 'false'"
+test "$TRAVIS_BRANCH" = "${DEPLOY_BRANCH:-master}" || \
+    exit_nice "TRAVIS_BRANCH '$TRAVIS_BRANCH' != '${DEPLOY_BRANCH:-master}'"
+test -n "$TAG" || error "TAG not set"
+
+
+################################################
+# Set up
+
+case $TAG in
+    raspbian)  DISTRO=raspbian; exit_nice "FIXME:  not pushing Raspbian packages" ;;
+    amd64|i386|armhf) DISTRO=jessie ;;
+    *) error "Unknown tag '$TAG'" ;;
+esac
+
+PACKAGECLOUD_REPO=${PACKAGECLOUD_REPO:-machinekit}
+PACKAGECLOUD_ARCHIVE=${PACKAGECLOUD_USER}/${PACKAGECLOUD_REPO}/debian/${DISTRO}
+
+
+################################################
+# Deploy
+
+if [ "${TAG}" = "amd64" ]; then
+    set -x  # Show user
+#    package_cloud push ${PACKAGECLOUD_ARCHIVE} ../*.dsc
+else
+    set -x  # Show user
+fi
+#package_cloud push ${PACKAGECLOUD_ARCHIVE} ../*_$TAG.deb

--- a/scripts/build_source_package
+++ b/scripts/build_source_package
@@ -1,0 +1,110 @@
+#!/bin/bash -e
+#
+# Update the Changelog file to create packages with version/release
+# that continuously increments (to ensure `apt-get upgrade` works) and
+# that contains identifying information about the package's source (to
+# indicate who built the package, how, and from what revision).
+
+
+# Whether to actually build the source
+BUILD_SOURCE=$1
+
+# Computed variables
+SOURCE_DIR=$(readlink -f $(dirname ${0})/..)
+test ${TRAVIS_PULL_REQUEST:-false} = false && IS_PR=false || IS_PR=true
+
+case $TAG in
+    amd64|i386|armhf) DISTRO=jessie ;;
+    raspbian) DISTRO=raspbian ;;
+esac
+
+COMMIT_TIMESTAMP="$(git log -1 --pretty=format:%at)"
+SHA1SHORT="$(git log -1 --pretty=format:%h)"
+COMMITTER_NAME="$(git log -1 --pretty=format:%an)"
+COMMITTER_EMAIL="$(git log -1 --pretty=format:%ae)"
+BRANCH_NAME="$(git rev-parse --symbolic-full-name HEAD)"
+BRANCH_NAME="${BRANCH_NAME//*\//}"  # convert / to -
+
+# Supplied variables for package configuration
+MAJOR_MINOR_VERSION="${MAJOR_MINOR_VERSION:-0.1}"
+TRAVIS_REPO=${TRAVIS_REPO_SLUG:+travis.${TRAVIS_REPO_SLUG/\//.}}
+PKGSOURCE="${PKGSOURCE:-${TRAVIS_REPO:-$(hostname)}}"
+DEBIAN_SUITE="${DEBIAN_SUITE:-experimental}"
+REPO_URL="${REPO_URL:-https://github.com/arceye/Machinekit-hal}"
+
+# Compute version
+if ${IS_PR}; then
+    # Use build timestamp (now) as pkg version patchlevel
+    TIMESTAMP="$(date +%s)"
+    PR_OR_BRANCH="pr${TRAVIS_PULL_REQUEST}"
+    COMMIT_URL="${REPO_URL}/pull/${TRAVIS_PULL_REQUEST}"
+else
+    # Use merge commit timestamp as pkg version patchlevel
+    TIMESTAMP="$COMMIT_TIMESTAMP"
+    PR_OR_BRANCH="${TRAVIS_BRANCH:-${BRANCH_NAME:-unk.branch}}"
+    COMMIT_URL="${REPO_URL}/commit/${SHA1SHORT}"
+fi
+
+# sanitize upstream identifier
+UPSTREAM_ID=${PKGSOURCE//[-_]/}.${PR_OR_BRANCH//[-_]/}
+
+# Final version
+VERSION="${MAJOR_MINOR_VERSION}.${TIMESTAMP}.git${SHA1SHORT}"
+
+# Final release
+RELEASE="1${UPSTREAM_ID}~1${DISTRO}"
+
+###########################################################
+# Debug output
+echo "COMMIT_TIMESTAMP=$COMMIT_TIMESTAMP"
+echo "SHA1SHORT=$SHA1SHORT"
+echo "COMMITTER_NAME=$COMMITTER_NAME"
+echo "COMMITTER_EMAIL=$COMMITTER_EMAIL"
+echo "BRANCH_NAME=$BRANCH_NAME"
+echo "MAJOR_MINOR_VERSION=$MAJOR_MINOR_VERSION"
+echo "TRAVIS_REPO=$TRAVIS_REPO"
+echo "PKGSOURCE=$PKGSOURCE"
+echo "DEBIAN_SUITE=$DEBIAN_SUITE"
+echo "REPO_URL=$REPO_URL"
+echo "TIMESTAMP=$TIMESTAMP"
+echo "PR_OR_BRANCH=$PR_OR_BRANCH"
+echo "COMMIT_URL=$COMMIT_URL"
+echo "UPSTREAM_ID=$UPSTREAM_ID"
+echo "VERSION=$VERSION"
+echo "RELEASE=$RELEASE"
+
+
+###########################################################
+# Generate debian/changelog entry
+#
+# https://www.debian.org/doc/debian-policy/ch-source.html#s-dpkgchangelog
+
+cd ${SOURCE_DIR}
+
+mv debian/changelog debian/changelog.orig
+cat > debian/changelog <<EOF
+machinekit-hal (${VERSION}-${RELEASE}) ${DEBIAN_SUITE}; urgency=low
+
+  * Travis CI rebuild
+    - TAG ${TAG}
+    - PR/branch ${PR_OR_BRANCH}
+    - Commit ${SHA1SHORT}
+    - ${COMMIT_URL}
+
+ -- ${COMMITTER_NAME} <${COMMITTER_EMAIL}>  $(date -R)
+
+EOF
+echo "New changelog entry:"
+cat debian/changelog # debug output
+cat debian/changelog.orig >> debian/changelog
+
+if test "$BUILD_SOURCE" = true; then
+    set -x # Let user see
+
+    # create .orig tarball
+    git archive HEAD | \
+	bzip2 -z | tee ../machinekit-hal_${VERSION}.orig.tar.bz2 >/dev/null
+
+    # build source package
+    dpkg-source -b .
+fi

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -541,9 +541,16 @@ AC_ARG_WITH(platform-pc,
     ],
     [
         case $host_cpu in
-	    (i?86 | x86_64)
+	    (x86_64)
+	        TARGET_PLATFORM_PC=unk
+		ARCH_CFLAGS="-m64"
+		;;
+	    (i?86)
+		ARCH_CFLAGS="-m32"
 	        TARGET_PLATFORM_PC=unk
 		;;
+
+
 	    (*)
 	        TARGET_PLATFORM_PC=false
 		platform_pc_reason="$arch_disab_msg"


### PR DESCRIPTION
This  PR contains a merge of two branches, which consolidate package building for Machinekit-HAL.

Packages can now be built by 3 different routes:

using the standard mk-builder docker Travis job, 
(wheezy & jessie, arm64, i386, armhf )

using the dovetailautomata-cross-builder docker from a Jenkins job (much faster) 
(jessie arm64, i386, armhf and raspbian armhf)

or, from the command line / local cross-build only at present to build for Stretch.
(stretch arm64, i386, armhf )

Once merged I will set up the Jenkins building job, which I have already tested on my own fork.
