### PR TITLE
Additional dependencies for machinekit-hal package in Jessie

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -15,6 +15,6 @@ Build-Depends: debhelper (>= 6),
     uuid-dev, uuid-runtime, libavahi-client-dev,
     libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
     python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
-    python-simplejson, libboost-thread-dev,
+    python-simplejson, libboost-thread-dev, libczmq2, libjansson4,
     python-pyftpdlib, @BUILD_DEPS@
 Standards-Version: 2.1.0

--- a/debian/postinst.in
+++ b/debian/postinst.in
@@ -9,6 +9,8 @@ cd /usr/share/pyshared/
 @PYTHON_EXECUTABLE@ hal/setup install --install-layout=deb > /dev/null
 @PYTHON_EXECUTABLE@ machinekit/setup install --install-layout=deb > /dev/null
 
+touch /var/log/linuxcnc.log
+
 # restart services
 service udev restart 2>/dev/null || true
 service rsyslog restart 2>/dev/null || true


### PR DESCRIPTION
Added libczmq2 and libjansson4 for Jessie packages

Also added creation of /var/log/linuxcnc.log to postinst

Signed-off-by: Mick <arceye@mgware.co.uk>