### PR TITLE
Put dependencies in correct control files

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -187,6 +187,10 @@ else
 echo "debian/control:  copied base template" >&2
 fi
 
+cp postinst.in machinekit-hal-posix.postinst
+cp postinst.in machinekit-hal-rt-preemmpt.postinst
+cp postinst.in machinekit-hal-xenomai.postinst
+
 cp rules.in rules; chmod +x rules
 echo "debian/rules:  copied base template" >&2
 #cp machinekit-hal-posix.install.in machinekit-hal-posix.install

--- a/debian/control.in
+++ b/debian/control.in
@@ -15,6 +15,6 @@ Build-Depends: debhelper (>= 6),
     uuid-dev, uuid-runtime, libavahi-client-dev,
     libprotobuf-dev (>= 2.4.1), protobuf-compiler (>= 2.4.1),
     python-protobuf (>= 2.4.1), libprotoc-dev (>= 2.4.1),
-    python-simplejson, libboost-thread-dev, libczmq2, libjansson4,
+    python-simplejson, libboost-thread-dev,
     python-pyftpdlib, @BUILD_DEPS@
 Standards-Version: 2.1.0

--- a/debian/control.posix.in
+++ b/debian/control.posix.in
@@ -6,7 +6,8 @@ Conflicts: machinekit
 Depends: ${misc:Depends},
     python-numpy, python-vte, python-xlib, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
-    python-avahi, bc, procps, psmisc, module-init-tools | kmod
+    python-avahi, bc, procps, psmisc, module-init-tools | kmod,
+    libczmq2, libjansson4
 Description: HAL stack split from Machinekit
  .
  This package provides components and drivers that run on a non-realtime

--- a/debian/control.rt-preempt.in
+++ b/debian/control.rt-preempt.in
@@ -6,7 +6,8 @@ Conflicts: machinekit
 Depends: ${misc:Depends},
     python-numpy, python-vte, python-xlib, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
-    python-avahi, bc, procps, psmisc, module-init-tools | kmod
+    python-avahi, bc, procps, psmisc, module-init-tools | kmod,
+    libczmq2, libjansson4
 Description: HAL stack split from machinekit
  .
  This package provides components and drivers that run on an RT-Preempt system.

--- a/debian/control.xenomai.in
+++ b/debian/control.xenomai.in
@@ -6,7 +6,8 @@ Conflicts: machinekit
 Depends: ${misc:Depends},
     xenomai-runtime, python-numpy, python-vte, python-xlib, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
-    python-avahi, bc, procps, psmisc, module-init-tools | kmod
+    python-avahi, bc, procps, psmisc, module-init-tools | kmod,
+    libczmq2, libjansson4
 Description: HAL stack split from machinekit
  .
  This package provides components and drivers that run on a Xenomai


### PR DESCRIPTION
Create build specific postinst files in the configure process

Signed-off-by: Mick <arceye@mgware.co.uk>