### PR TITLE
Make dependency upon yapps2-runtime for comp/instcomp

### DIFF
--- a/debian/control.posix-stretch.in
+++ b/debian/control.posix-stretch.in
@@ -6,7 +6,7 @@ Conflicts: machinekit
 Depends: ${misc:Depends},
     python-numpy, python-vte, python-xlib, python-configobj,
     czmq, zeromq, python-protobuf (>= 2.4.1), python-gst-1.0,
-    python-avahi, bc, procps, psmisc, module-init-tools | kmod
+    python-avahi, bc, procps, psmisc, module-init-tools | kmod, yapps2-runtime
 Description: HAL stack split from Machinekit
  .
  This package provides components and drivers that run on a non-realtime

--- a/debian/control.posix.in
+++ b/debian/control.posix.in
@@ -7,7 +7,7 @@ Depends: ${misc:Depends},
     python-numpy, python-vte, python-xlib, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
     python-avahi, bc, procps, psmisc, module-init-tools | kmod,
-    libczmq2, libjansson4
+    libczmq2, libjansson4, yapps2-runtime
 Description: HAL stack split from Machinekit
  .
  This package provides components and drivers that run on a non-realtime

--- a/debian/control.rt-preempt-stretch.in
+++ b/debian/control.rt-preempt-stretch.in
@@ -6,7 +6,7 @@ Conflicts: machinekit
 Depends: ${misc:Depends},
     python-numpy, python-vte, python-xlib, python-configobj,
     zeromq, czmq, python-protobuf (>= 2.4.1), python-gst-1.0,
-    python-avahi, bc, procps, psmisc, module-init-tools | kmod,
+    python-avahi, bc, procps, psmisc, module-init-tools | kmod, yapps2-runtime,
     linux-image-rt-686-pae [i386], linux-image-rt-amd64 [amd64]
 Description: HAL stack split from machinekit
  .

--- a/debian/control.rt-preempt.in
+++ b/debian/control.rt-preempt.in
@@ -7,7 +7,7 @@ Depends: ${misc:Depends},
     python-numpy, python-vte, python-xlib, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
     python-avahi, bc, procps, psmisc, module-init-tools | kmod,
-    libczmq2, libjansson4
+    libczmq2, libjansson4, yapps2-runtime
 Description: HAL stack split from machinekit
  .
  This package provides components and drivers that run on an RT-Preempt system.

--- a/debian/control.xenomai.in
+++ b/debian/control.xenomai.in
@@ -7,7 +7,7 @@ Depends: ${misc:Depends},
     xenomai-runtime, python-numpy, python-vte, python-xlib, python-configobj,
     python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
     python-avahi, bc, procps, psmisc, module-init-tools | kmod,
-    libczmq2, libjansson4
+    libczmq2, libjansson4, yapps2-runtime
 Description: HAL stack split from machinekit
  .
  This package provides components and drivers that run on a Xenomai


### PR DESCRIPTION
Packaging does not include the runtime.pyc generated in a RIP build
so required from other sources

Signed-off-by: Mick <arceye@mgware.co.uk>