### PR TITLE
Revert commit 9ca3e60 in respect of pru_generic.bin generation

### DIFF
--- a/debian/machinekit-hal-posix.install.in
+++ b/debian/machinekit-hal-posix.install.in
@@ -12,7 +12,7 @@ usr/lib/python*/*/*/*.so
 usr/lib/python*/*/machinetalk/protobuf/*
 usr/lib/python*/*/machinetalk/*.py
 usr/lib/python*/*/machinekit/nosetests/*.py
-usr/lib/linuxcnc/posix/*
+usr/lib/linuxcnc/posix/*.so
 usr/include/linuxcnc/*.h
 usr/include/linuxcnc/*.hh
 usr/libexec/linuxcnc/pci_read

--- a/debian/machinekit-hal-rt-preempt.install.in
+++ b/debian/machinekit-hal-rt-preempt.install.in
@@ -12,7 +12,7 @@ usr/lib/python*/*/*/*.so
 usr/lib/python*/*/machinetalk/protobuf/*
 usr/lib/python*/*/machinetalk/*.py
 usr/lib/python*/*/machinekit/nosetests/*.py
-usr/lib/linuxcnc/rt-preempt/*
+usr/lib/linuxcnc/rt-preempt/*.so
 usr/include/linuxcnc/*.h
 usr/include/linuxcnc/*.hh
 usr/libexec/linuxcnc/pci_read

--- a/src/hal/drivers/hal_pru_generic/Submakefile
+++ b/src/hal/drivers/hal_pru_generic/Submakefile
@@ -18,9 +18,9 @@ PRU_DBG := $(patsubst %,$(RTLIBDIR)/%.dbg,$(PRU_MAINS))
 # the first defined RTOS flavor (typically posix)
 #TARGETS +=  $(PRU_BIN) $(PRU_DBG)
 # Only build PRU code for the Xenomai RTOS flavor
-#ifeq ($(threads),xenomai)
+ifeq ($(threads),xenomai)
 modules : $(PRU_BIN) $(PRU_DBG)
-#endif
+endif
 
 # .bin output, create listing
 PASM_BINFLAGS := -b -L -d


### PR DESCRIPTION
Creation of the pru_*.* files for all flavours,
caused a problem in the build environment as yet unresolved.

Removed for now to ensure everything else works.