### PR TITLE
Move PASM generated pru_generic.bin etc. into all flavours

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -188,8 +188,10 @@ echo "debian/control:  copied base template" >&2
 fi
 
 cp postinst.in machinekit-hal-posix.postinst
-cat postinst.in rt-preempt-postinst.add > machinekit-hal-rt-preempt.postinst
-cat postinst.in xenomai-postinst.add > machinekit-hal-xenomai.postinst
+cp postinst.in machinekit-hal-rt-preempt.postinst
+cp postinst.in machinekit-hal-xenomai.postinst
+#cat postinst.in rt-preempt-postinst.add > machinekit-hal-rt-preempt.postinst
+#cat postinst.in xenomai-postinst.add > machinekit-hal-xenomai.postinst
 
 cp rules.in rules; chmod +x rules
 echo "debian/rules:  copied base template" >&2

--- a/debian/configure
+++ b/debian/configure
@@ -188,8 +188,8 @@ echo "debian/control:  copied base template" >&2
 fi
 
 cp postinst.in machinekit-hal-posix.postinst
-cp postinst.in machinekit-hal-rt-preempt.postinst
-cp postinst.in machinekit-hal-xenomai.postinst
+cat postinst.in rt-preempt-postinst.add > machinekit-hal-rt-preempt.postinst
+cat postinst.in xenomai-postinst.add > machinekit-hal-xenomai.postinst
 
 cp rules.in rules; chmod +x rules
 echo "debian/rules:  copied base template" >&2

--- a/debian/machinekit-hal-posix.install.in
+++ b/debian/machinekit-hal-posix.install.in
@@ -13,7 +13,7 @@ usr/lib/python*/*/machinetalk/protobuf/*
 usr/lib/python*/*/machinetalk/*.py
 usr/lib/python*/*/machinekit/nosetests/*.py
 usr/lib/python*/*/fdm/config/*.py
-usr/lib/linuxcnc/posix/*.so
+usr/lib/linuxcnc/posix/*
 usr/include/linuxcnc/*.h
 usr/include/linuxcnc/*.hh
 usr/libexec/linuxcnc/pci_read

--- a/debian/machinekit-hal-rt-preempt.install.in
+++ b/debian/machinekit-hal-rt-preempt.install.in
@@ -14,8 +14,8 @@ usr/lib/python*/*/machinetalk/*.py
 usr/lib/python*/*/machinekit/nosetests/*.py
 usr/lib/python*/*/fdm/config/*.py
 usr/lib/linuxcnc/rt-preempt/*
-usr/lib/linuxcnc/posix/*.bin
-usr/lib/linuxcnc/posix/*.dbg
+#usr/lib/linuxcnc/posix/*.bin
+#usr/lib/linuxcnc/posix/*.dbg
 usr/include/linuxcnc/*.h
 usr/include/linuxcnc/*.hh
 usr/libexec/linuxcnc/pci_read

--- a/debian/machinekit-hal-rt-preempt.install.in
+++ b/debian/machinekit-hal-rt-preempt.install.in
@@ -13,7 +13,9 @@ usr/lib/python*/*/machinetalk/protobuf/*
 usr/lib/python*/*/machinetalk/*.py
 usr/lib/python*/*/machinekit/nosetests/*.py
 usr/lib/python*/*/fdm/config/*.py
-usr/lib/linuxcnc/rt-preempt/*.so
+usr/lib/linuxcnc/rt-preempt/*
+usr/lib/linuxcnc/posix/*.bin
+usr/lib/linuxcnc/posix/*.dbg
 usr/include/linuxcnc/*.h
 usr/include/linuxcnc/*.hh
 usr/libexec/linuxcnc/pci_read

--- a/debian/machinekit-hal-xenomai.install.in
+++ b/debian/machinekit-hal-xenomai.install.in
@@ -13,8 +13,8 @@ usr/lib/python*/*/machinetalk/*.py
 usr/lib/python*/*/machinekit/nosetests/*.py
 usr/lib/python*/*/fdm/config/*.py
 usr/lib/linuxcnc/xenomai/*
-usr/lib/linuxcnc/posix/*.bin
-usr/lib/linuxcnc/posix/*.dbg
+#usr/lib/linuxcnc/posix/*.bin
+#usr/lib/linuxcnc/posix/*.dbg
 usr/include/linuxcnc/*.h
 usr/include/linuxcnc/*.hh
 usr/libexec/linuxcnc/pci_read

--- a/debian/machinekit-hal-xenomai.install.in
+++ b/debian/machinekit-hal-xenomai.install.in
@@ -13,6 +13,8 @@ usr/lib/python*/*/machinetalk/*.py
 usr/lib/python*/*/machinekit/nosetests/*.py
 usr/lib/python*/*/fdm/config/*.py
 usr/lib/linuxcnc/xenomai/*
+usr/lib/linuxcnc/posix/*.bin
+usr/lib/linuxcnc/posix/*.dbg
 usr/include/linuxcnc/*.h
 usr/include/linuxcnc/*.hh
 usr/libexec/linuxcnc/pci_read

--- a/debian/rt-preempt-postinst.add
+++ b/debian/rt-preempt-postinst.add
@@ -1,0 +1,4 @@
+
+# move the BBB pru_*.* to the correct dir
+mv /usr/lib/linuxcnc/posix/* /usr/lib/linuxcnc/rt-preempt
+rmdir /usr/lib/linuxcnc/posix

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -136,6 +136,18 @@ install: build
 	    echo "usr/include/linuxcnc/userpci/*.h" >> debian/machinekit-hal-xenomai.install; \
 	fi
 
+	## only want this for armhf builds ##
+	if [ -f debian/platform_pc ] ; then \
+	    rm -f debian/platform_pc; \
+	else \
+	    cat debian/rt-preempt-postinst.add >> debian/machinekit-hal-rt-preempt.postinst; \
+	    cat debian/xenomai-postinst.add >> debian/machinekit-hal-xenomai.postinst; \
+	    echo "usr/lib/linuxcnc/posix/*.bin" >> debian/machinekit-hal-rt-preempt.install; \
+	    echo "usr/lib/linuxcnc/posix/*.dbg" >> debian/machinekit-hal-rt-preempt.install; \
+	    echo "usr/lib/linuxcnc/posix/*.bin" >> debian/machinekit-hal-xenomai.install; \
+	    echo "usr/lib/linuxcnc/posix/*.dbg" >> debian/machinekit-hal-xenomai.install; \
+	fi
+
 	dh_testdir
 	dh_testroot
 	dh_prep

--- a/debian/xenomai-postinst.add
+++ b/debian/xenomai-postinst.add
@@ -1,0 +1,5 @@
+
+# move the BBB pru_*.* files to correct dir
+mv /usr/lib/linuxcnc/posix/* /usr/lib/linuxcnc/xenomai
+rmdir /usr/lib/linuxcnc/posix
+

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -765,6 +765,11 @@ else
     fi
 fi
 
+if test $TARGET_PLATFORM_PC = true; then
+	echo "*** TARGET_PLATFORM_PC=true ***"
+	touch ../debian/platform_pc
+    fi
+
 # Print messages about what platforms are to be enabled or disabled
 AC_MSG_CHECKING(platform-pc)
 AC_MSG_RESULT([$platform_pc_reason])

--- a/src/hal/drivers/hal_pru_generic/Submakefile
+++ b/src/hal/drivers/hal_pru_generic/Submakefile
@@ -18,8 +18,8 @@ PRU_DBG := $(patsubst %,$(RTLIBDIR)/%.dbg,$(PRU_MAINS))
 # the first defined RTOS flavor (typically posix)
 #TARGETS +=  $(PRU_BIN) $(PRU_DBG)
 # Only build PRU code for the Xenomai RTOS flavor
-ifeq ($(threads),xenomai)
-modules : $(PRU_BIN) $(PRU_DBG)
+ifeq ($(threads), posix)
+modules : $(PRU_BIN) $(PRU_DBG) 
 endif
 
 # .bin output, create listing


### PR DESCRIPTION
Was restricted to xenomai originally and there is now a requirement
to be able to run BBB on rt-preempt kernels, which also require
the files

Since they are of a binary format which is not flavour dependent
they are now built once for posix, incorporated into each
package, to be moved to the correct location upon install

Fixes #17

Signed-off-by: mick <arceye@mgware.co.uk>