### PR TITLE
Component jplan for some reason was not properly linked.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1257,7 +1257,7 @@ scope_rt-objs := hal/utils/scope_rt.o $(MATHSTUB)
 # vtexport-objs += hal/vtable-example/vcode.o
 
 obj-m += jplan.o
-jplan-objs := hal/jplanner/jplan.o
+jplan-objs := hal/jplanner/jplan.o machinetalk/build/machinetalk/protobuf/jplan.npb.o
 
 obj-m += interpolate.o
 interpolate-objs := hal/interpolator/interpolate.o


### PR DESCRIPTION
Symbols within the generated jplan.npb.o
were not being linked correctly

Specific linkage added to Makefile, which produces a jplan
module which loads

Fixes #22

Signed-off-by: Mick <arceye@mgware.co.uk>