### PR TITLE
Make PASM created pru_generic* binaries flavour independent.

### DIFF
--- a/debian/machinekit-hal-posix.install.in
+++ b/debian/machinekit-hal-posix.install.in
@@ -30,4 +30,3 @@ usr/share/linuxcnc/*.png
 usr/share/linuxcnc/Makefile.*
 usr/share/linuxcnc/udev/90-xhc.rules
 usr/share/fdm/thermistor_tables/*
-

--- a/debian/machinekit-hal-rt-preempt.install.in
+++ b/debian/machinekit-hal-rt-preempt.install.in
@@ -14,8 +14,6 @@ usr/lib/python*/*/machinetalk/*.py
 usr/lib/python*/*/machinekit/nosetests/*.py
 usr/lib/python*/*/fdm/config/*.py
 usr/lib/linuxcnc/rt-preempt/*
-#usr/lib/linuxcnc/posix/*.bin
-#usr/lib/linuxcnc/posix/*.dbg
 usr/include/linuxcnc/*.h
 usr/include/linuxcnc/*.hh
 usr/libexec/linuxcnc/pci_read

--- a/debian/machinekit-hal-xenomai.install.in
+++ b/debian/machinekit-hal-xenomai.install.in
@@ -13,8 +13,6 @@ usr/lib/python*/*/machinetalk/*.py
 usr/lib/python*/*/machinekit/nosetests/*.py
 usr/lib/python*/*/fdm/config/*.py
 usr/lib/linuxcnc/xenomai/*
-#usr/lib/linuxcnc/posix/*.bin
-#usr/lib/linuxcnc/posix/*.dbg
 usr/include/linuxcnc/*.h
 usr/include/linuxcnc/*.hh
 usr/libexec/linuxcnc/pci_read

--- a/debian/posix-postinst.add
+++ b/debian/posix-postinst.add
@@ -1,0 +1,6 @@
+
+# make symlinks to BBB pru_*.*
+ln -s /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/posix/pru_generic.bin
+ln -s /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/posix/pru_generic.dbg
+ln -s /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/posix/pru_decamux.bin
+ln -s /usr/lib/linuxcnc/prubin/pru_decamux.dbg /usr/lib/linuxcnc/posix/pru_decamux.dbg

--- a/debian/rt-preempt-postinst.add
+++ b/debian/rt-preempt-postinst.add
@@ -1,4 +1,6 @@
 
-# move the BBB pru_*.* to the correct dir
-mv /usr/lib/linuxcnc/posix/* /usr/lib/linuxcnc/rt-preempt
-rmdir /usr/lib/linuxcnc/posix
+# make symlinks to BBB pru_*.*
+ln -s /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/rt-preempt/pru_generic.bin
+ln -s /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/rt-preempt/pru_generic.dbg
+ln -s /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/rt-preempt/pru_decamux.bin
+ln -s /usr/lib/linuxcnc/prubin/pru_decamux.dbg /usr/lib/linuxcnc/rt-preempt/pru_decamux.dbg

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -137,15 +137,10 @@ install: build
 	fi
 
 	## only want this for armhf builds ##
-	if [ -f debian/platform_pc ] ; then \
-	    rm -f debian/platform_pc; \
-	else \
-	    cat debian/rt-preempt-postinst.add >> debian/machinekit-hal-rt-preempt.postinst; \
-	    cat debian/xenomai-postinst.add >> debian/machinekit-hal-xenomai.postinst; \
-	    echo "usr/lib/linuxcnc/posix/*.bin" >> debian/machinekit-hal-rt-preempt.install; \
-	    echo "usr/lib/linuxcnc/posix/*.dbg" >> debian/machinekit-hal-rt-preempt.install; \
-	    echo "usr/lib/linuxcnc/posix/*.bin" >> debian/machinekit-hal-xenomai.install; \
-	    echo "usr/lib/linuxcnc/posix/*.dbg" >> debian/machinekit-hal-xenomai.install; \
+	if [ ! -f debian/platform_pc ] ; then \
+	    echo "usr/lib/linuxcnc/prubin/*" >> debian/machinekit-hal-posix.install; \
+	    echo "usr/lib/linuxcnc/prubin/*" >> debian/machinekit-hal-rt-preempt.install; \
+	    echo "usr/lib/linuxcnc/prubin/*" >> debian/machinekit-hal-xenomai.install; \
 	fi
 
 	dh_testdir
@@ -168,6 +163,17 @@ install: build
 	mkdir -p debian/tmp/etc/security/limits.d
 	cp src/rtapi/shmdrv/limits.d-machinekit.conf \
 	    debian/tmp/etc/security/limits.d/machinekit.conf
+
+	## only want this for armhf builds too ##
+	if [ -f debian/platform_pc ] ; then \
+	    rm -f debian/platform_pc; \
+	else \
+	    mkdir -p debian/tmp/usr/lib/linuxcnc/prubin; \
+	    cp rtlib/prubin/* debian/tmp/usr/lib/linuxcnc/prubin; \
+	    cat debian/posix-postinst.add >> debian/machinekit-hal-posix.postinst; \
+	    cat debian/rt-preempt-postinst.add >> debian/machinekit-hal-rt-preempt.postinst; \
+	    cat debian/xenomai-postinst.add >> debian/machinekit-hal-xenomai.postinst; \
+	fi
 
 	dh_install --sourcedir=debian/tmp --fail-missing -Xusr/bin/pasm
 

--- a/debian/xenomai-postinst.add
+++ b/debian/xenomai-postinst.add
@@ -1,5 +1,6 @@
 
-# move the BBB pru_*.* files to correct dir
-mv /usr/lib/linuxcnc/posix/* /usr/lib/linuxcnc/xenomai
-rmdir /usr/lib/linuxcnc/posix
-
+# make symlinks to BBB pru_*.*
+ln -s /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/xenomai/pru_generic.bin
+ln -s /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/xenomai/pru_generic.dbg
+ln -s /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/xenomai/pru_decamux.bin
+ln -s /usr/lib/linuxcnc/prubin/pru_decamux.dbg /usr/lib/linuxcnc/xenomai/pru_decamux.dbg

--- a/src/Makefile
+++ b/src/Makefile
@@ -151,14 +151,14 @@ ifeq ($(RUN_IN_PLACE)+$(BUILD_DRIVERS),yes+yes)
 		    \( 0`stat -c %u ../libexec/rtapi_app_$$f 2>/dev/null` \
 			-ne 0 -o ! -u ../libexec/rtapi_app_$$f \) \
 		&& need_setuid=1; \
-	    if [ "$$f" != "posix" ]; then \
-		cp -f ../rtlib/posix/pru_*.bin ../rtlib/$$f; \
-		cp -f ../rtlib/posix/pru_*.dbg ../rtlib/$$f; \
-	    fi; \
+	    ln -s $(EMC2_HOME)/rtlib/prubin/pru_generic.bin ../rtlib/$$f/pru_generic.bin; \
+	    ln -s $(EMC2_HOME)/rtlib/prubin/pru_generic.dbg ../rtlib/$$f/pru_generic.dbg; \
+	    ln -s $(EMC2_HOME)/rtlib/prubin/pru_decamux.bin ../rtlib/$$f/pru_decamux.bin; \
+	    ln -s $(EMC2_HOME)/rtlib/prubin/pru_decamux.dbg ../rtlib/$$f/pru_decamux.dbg; \
 	done; \
 	test "$$need_setuid" = 1 && \
 	    $(VECHO) -n "You now need to run 'sudo make setuid' " && \
-	    $(VECHO) "in order to run in place." || true 
+	    $(VECHO) "in order to run in place." || true
 endif
 
 endif # BUILD_ALL_FLAVORS

--- a/src/hal/components/hal_pru.c
+++ b/src/hal/components/hal_pru.c
@@ -22,7 +22,7 @@
 #include <unistd.h>
 
 // load this PRU code (prefixed by EMC_RTLIB_DIR)
-#define  DEFAULT_CODE  "blinkleds.bin"
+#define  DEFAULT_CODE  "pru_generic.bin"
 
 #include "prussdrv.h"           // UIO interface to uio_pruss
 #include "pru.h"                // PRU-related defines
@@ -334,27 +334,29 @@ static int setup_pru(int pru, char *filename, int disabled)
     char pru_binpath[PATH_MAX];
 
     // default the .bin filename if not given
-    if (!strlen(filename))
+    if (!strlen(filename)){
+	rtapi_print_msg(RTAPI_MSG_ERR, 
+	    "%s: no filename given - default to %s\n",
+	    modname, DEFAULT_CODE);
 	filename = DEFAULT_CODE;
-    
+	}
     strcpy(pru_binpath, filename);
 
     struct stat statb;
 
     if (!((stat(pru_binpath, &statb) == 0) &&
 	 S_ISREG(statb.st_mode))) {
-
+	rtapi_print_msg(RTAPI_MSG_ERR, 
+	    "%s: filename %s does not exist.\n", modname, pru_binpath);
 	// filename not found, prefix fw_path & try that:
 	strcpy(pru_binpath, fw_path);
 	strcat(pru_binpath, filename);
 
 	if (!((stat(pru_binpath, &statb) == 0) &&
 	      S_ISREG(statb.st_mode))) {
-	    // nyet, complain
-	    getcwd(pru_binpath, sizeof(pru_binpath));
 	    rtapi_print_msg(RTAPI_MSG_ERR,
-			    "%s: cant find %s in %s or %s\n",
-			    modname, filename, pru_binpath, fw_path);
+		"%s: cannot find filename %s\n",
+		modname, pru_binpath);
 	    return -ENOENT;
 	}
     }

--- a/src/hal/drivers/hal_pru_generic/Submakefile
+++ b/src/hal/drivers/hal_pru_generic/Submakefile
@@ -1,5 +1,14 @@
 ifdef TARGET_PLATFORM_BEAGLEBONE
 
+# These are actually the same location but the package
+# build needs to set a path relative to the Makefile,
+# from whence it will be copied to debian/tmp
+ifeq ($(RUN_IN_PLACE),yes)
+PRUBINDIR := $(EMC2_HOME)/rtlib/prubin
+else
+PRUBINDIR := ../rtlib/prubin
+endif
+
 # support for ARM335x PRU (Programmable Realtime Unit) components and
 SUPPORT_DIR := hal/support
 PRU_SRC_DIR := hal/drivers/hal_pru_generic
@@ -10,17 +19,10 @@ PRU_MAINS   := pru_generic pru_decamux
 PRU_FILES := $(wildcard $(PRU_SRC_DIR)/*.p)
 
 # .bin file produced by PASM -b goes in rtlib
-PRU_BIN := $(patsubst %,$(RTLIBDIR)/%.bin,$(PRU_MAINS))
-PRU_DBG := $(patsubst %,$(RTLIBDIR)/%.dbg,$(PRU_MAINS))
+PRU_BIN := $(patsubst %,$(PRUBINDIR)/%.bin,$(PRU_MAINS))
+PRU_DBG := $(patsubst %,$(PRUBINDIR)/%.dbg,$(PRU_MAINS))
 
-# .bin files are targets
-# Adding to TARGETS builds the PRU code once and puts it in the RTLIBDIR for
-# the first defined RTOS flavor (typically posix)
-#TARGETS +=  $(PRU_BIN) $(PRU_DBG)
-# Only build PRU code for the Xenomai RTOS flavor
-ifeq ($(threads), posix)
 modules : $(PRU_BIN) $(PRU_DBG) 
-endif
 
 # .bin output, create listing
 PASM_BINFLAGS := -b -L -d
@@ -28,7 +30,7 @@ PASM_BINFLAGS := -b -L -d
 # conversion rule for the above
 # assemble .p  into .bin object files
 
-$(RTLIBDIR)/%.bin $(RTLIBDIR)/%.dbg: $(PASM) 
+$(PRUBINDIR)/%.bin $(PRUBINDIR)/%.dbg: $(PASM) 
 
 
 PRU_DEPS := $(patsubst %,objects/%,$(patsubst %,$(PRU_SRC_DIR)/%.d,$(PRU_MAINS)))
@@ -41,14 +43,14 @@ $(PRU_DEPS): objects/%.d : %.p
 	$(Q)cpp -x c -MM -MG -MT objects/$(patsubst %.p,%.bin,$<) -o $@ $<
 
 objects/%.bin objects/%.dbg : %.p objects/%.d $(PASM)
-	$(Q)mkdir -p $(RTLIBDIR)
+	$(Q)mkdir -p $(PRUBINDIR)
 	$(ECHO) Assembling PRU code $@ 
 	$(Q)$(PASM) $(PASM_BINFLAGS) $< $(basename $@)
 
-$(PRU_BIN): $(RTLIBDIR)/%.bin : objects/$(PRU_SRC_DIR)/%.bin
-	cp $^ $@
+$(PRU_BIN): $(PRUBINDIR)/%.bin : objects/$(PRU_SRC_DIR)/%.bin
+	cp -f $^ $@
 
-$(PRU_DBG): $(RTLIBDIR)/%.dbg : objects/$(PRU_SRC_DIR)/%.dbg
-	cp $^ $@
+$(PRU_DBG): $(PRUBINDIR)/%.dbg : objects/$(PRU_SRC_DIR)/%.dbg
+	cp -f $^ $@
 
 endif


### PR DESCRIPTION
They will now be located at $EMC2_RTLIB_BASE_DIR/prubin for binaries
and $EMC_HOME/rtlib/prubin for RIP builds
ie. in a dir immediately alongside the existing flavour dirs
then symlinked to each flavour dir so that configs are unchanged.

Signed-off-by: Mick <arceye@mgware.co.uk>