### PR TITLE
Correct typo of the omission variety

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -199,7 +199,7 @@ echo "debian/rules:  copied base template" >&2
 #echo "debian/machinekit-hal-posix.install.in:  copied base template" >&2
 
 # read command line options - d is a dummy to stop args being req
-while getopts prxd:t:?h ARG; do
+while getopts csprxd:t:?h ARG; do
     case $ARG in
 	p) do_posix ;;
 	r) do_rt-preempt ;;


### PR DESCRIPTION
Options -c and -s missing from the opt args, meaning local
package builds cannot set version strings and build sources
with those switches.

Signed-off-by: Mick <arceye@mgware.co.uk>