### PR TITLE
Additions to clean up any symlinks to pru_* files

### DIFF
--- a/debian/armhf.postrm.in
+++ b/debian/armhf.postrm.in
@@ -1,0 +1,5 @@
+
+# remove the whole dir and contents, uninstall will have left it
+# because the symlinks still exist
+
+rm -r -d -f /usr/lib/linuxcnc

--- a/debian/posix-postinst.add
+++ b/debian/posix-postinst.add
@@ -1,4 +1,11 @@
 
+# ensure the links do not pre-exist, from previous installs.
+# or user work-arounds,  which will produce error messages
+rm -f /usr/lib/linuxcnc/posix/pru_generic.bin
+rm -f /usr/lib/linuxcnc/posix/pru_generic.dbg
+rm -f /usr/lib/linuxcnc/posix/pru_decamux.bin
+rm -f /usr/lib/linuxcnc/posix/pru_decamux.dbg
+
 # make symlinks to BBB pru_*.*
 ln -s /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/posix/pru_generic.bin
 ln -s /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/posix/pru_generic.dbg

--- a/debian/postinst.in
+++ b/debian/postinst.in
@@ -2,6 +2,7 @@
 # postinst script for machinekit-hal
 
 touch /var/log/linuxcnc.log
+chmod 666 /var/log/linuxcnc.log
 
 # restart services
 service udev restart 2>/dev/null || true

--- a/debian/rt-preempt-postinst.add
+++ b/debian/rt-preempt-postinst.add
@@ -1,4 +1,11 @@
 
+# ensure the links do not pre-exist, from previous installs 
+# or user work-arounds,  which will produce error messages
+rm -f /usr/lib/linuxcnc/rt-preempt/pru_generic.bin
+rm -f /usr/lib/linuxcnc/rt-preempt/pru_generic.dbg
+rm -f /usr/lib/linuxcnc/rt-preempt/pru_decamux.bin
+rm -f /usr/lib/linuxcnc/rt-preempt/pru_decamux.dbg
+
 # make symlinks to BBB pru_*.*
 ln -s /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/rt-preempt/pru_generic.bin
 ln -s /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/rt-preempt/pru_generic.dbg

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -173,6 +173,9 @@ install: build
 	    cat debian/posix-postinst.add >> debian/machinekit-hal-posix.postinst; \
 	    cat debian/rt-preempt-postinst.add >> debian/machinekit-hal-rt-preempt.postinst; \
 	    cat debian/xenomai-postinst.add >> debian/machinekit-hal-xenomai.postinst; \
+	    cat debian/armhf.postrm.in >> debian/machinekit-hal-posix.postrm; \
+	    cat debian/armhf.postrm.in >> debian/machinekit-hal-rt-preempt.postrm; \
+	    cat debian/armhf.postrm.in >> debian/machinekit-hal-xenomai.postrm; \
 	fi
 
 	dh_install --sourcedir=debian/tmp --fail-missing -Xusr/bin/pasm

--- a/debian/xenomai-postinst.add
+++ b/debian/xenomai-postinst.add
@@ -1,4 +1,11 @@
 
+# ensure the links do not pre-exist, from previous installs.
+# or user work-arounds,  which will produce error messages
+rm -f /usr/lib/linuxcnc/xenomai/pru_generic.bin
+rm -f /usr/lib/linuxcnc/xenomai/pru_generic.dbg
+rm -f /usr/lib/linuxcnc/xenomai/pru_decamux.bin
+rm -f /usr/lib/linuxcnc/xenomai/pru_decamux.dbg
+
 # make symlinks to BBB pru_*.*
 ln -s /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/xenomai/pru_generic.bin
 ln -s /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/xenomai/pru_generic.dbg


### PR DESCRIPTION
Because the symlinks are created post install, when package
is removed, the symlinks will be orphaned and the dir housing
will not be deleted.

Will also prevent warnings if user has already `jury-rigged`
symlinks to get access to pru_* files for rt-preempt

Signed-off-by: Mick <arceye@mgware.co.uk>