### PR TITLE
Tidy up and return python-zmq and libjansson to install depends for Stretch

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -88,9 +88,16 @@ do_tcl_tk_version() {
 }
 
 do_xenomai() {
+    if [[ $DISTRO_CODENAME == "stretch" ]] ; then
+	cat control.xenomai-stretch.in >> control
+	echo "debian/control:  added xenomai threads package for Stretch" >&2
+    else
+	cat control.xenomai.in >> control
+	echo "debian/control:  added xenomai threads package for Wheezy/Jessie" >&2
+    fi
+
     # Be sure the -dev files only appear once
     BUILD_DEPS="${BUILD_DEPS/libxenomai-dev, /}libxenomai-dev, "
-    cat control.xenomai.in >> control
     echo "debian/control:  added Xenomai (userland) threads package" \
 	"with Build-Depends:" >&2
     echo "    libxenomai-dev" >&2
@@ -190,13 +197,9 @@ fi
 cp postinst.in machinekit-hal-posix.postinst
 cp postinst.in machinekit-hal-rt-preempt.postinst
 cp postinst.in machinekit-hal-xenomai.postinst
-#cat postinst.in rt-preempt-postinst.add > machinekit-hal-rt-preempt.postinst
-#cat postinst.in xenomai-postinst.add > machinekit-hal-xenomai.postinst
 
 cp rules.in rules; chmod +x rules
 echo "debian/rules:  copied base template" >&2
-#cp machinekit-hal-posix.install.in machinekit-hal-posix.install
-#echo "debian/machinekit-hal-posix.install.in:  copied base template" >&2
 
 # read command line options - d is a dummy to stop args being req
 while getopts csprxd:t:?h ARG; do

--- a/debian/control.posix-stretch.in
+++ b/debian/control.posix-stretch.in
@@ -6,7 +6,8 @@ Conflicts: machinekit
 Depends: ${misc:Depends},
     python-numpy, python-vte, python-xlib, python-configobj,
     czmq, zeromq, python-protobuf (>= 2.4.1), python-gst-1.0,
-    python-avahi, bc, procps, psmisc, module-init-tools | kmod, yapps2-runtime
+    python-avahi, bc, procps, psmisc, module-init-tools | kmod, 
+    yapps2-runtime, python-zmq, libjansson4
 Description: HAL stack split from Machinekit
  .
  This package provides components and drivers that run on a non-realtime

--- a/debian/control.rt-preempt-stretch.in
+++ b/debian/control.rt-preempt-stretch.in
@@ -6,7 +6,8 @@ Conflicts: machinekit
 Depends: ${misc:Depends},
     python-numpy, python-vte, python-xlib, python-configobj,
     zeromq, czmq, python-protobuf (>= 2.4.1), python-gst-1.0,
-    python-avahi, bc, procps, psmisc, module-init-tools | kmod, yapps2-runtime,
+    python-avahi, bc, procps, psmisc, module-init-tools | kmod, 
+    yapps2-runtime, python-zmq, libjansson4,
     linux-image-rt-686-pae [i386], linux-image-rt-amd64 [amd64]
 Description: HAL stack split from machinekit
  .

--- a/debian/control.xenomai-stretch.in
+++ b/debian/control.xenomai-stretch.in
@@ -1,0 +1,14 @@
+
+Package: machinekit-hal-xenomai
+Architecture: any
+Provides:  machinekit-hal
+Conflicts: machinekit
+Depends: ${misc:Depends},
+    xenomai-runtime, python-numpy, python-vte, python-xlib, python-configobj,
+    python-protobuf (>= 2.4.1), python-gst-1.0,
+    python-avahi, bc, procps, psmisc, module-init-tools | kmod,
+    zeromq, czmq, libjansson4, yapps2-runtime, python-zmq
+Description: HAL stack split from machinekit
+ .
+ This package provides components and drivers that run on a Xenomai
+ realtime system, with userspace threads.


### PR DESCRIPTION
python-zmq needs to continue to be absent from the build deps, 
because it is not required for the build and pulls in libzeromq5, 
which is currently incompatible with the machinekit/machinekit-hal code.