### PR TITLE
Force creation of symlinks for armhf pru_*.* binaries

### DIFF
--- a/debian/posix-postinst.add
+++ b/debian/posix-postinst.add
@@ -7,7 +7,7 @@ rm -f /usr/lib/linuxcnc/posix/pru_decamux.bin
 rm -f /usr/lib/linuxcnc/posix/pru_decamux.dbg
 
 # make symlinks to BBB pru_*.*
-ln -s /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/posix/pru_generic.bin
-ln -s /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/posix/pru_generic.dbg
-ln -s /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/posix/pru_decamux.bin
-ln -s /usr/lib/linuxcnc/prubin/pru_decamux.dbg /usr/lib/linuxcnc/posix/pru_decamux.dbg
+ln -sf /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/posix/pru_generic.bin
+ln -sf /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/posix/pru_generic.dbg
+ln -sf /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/posix/pru_decamux.bin
+ln -sf /usr/lib/linuxcnc/prubin/pru_decamux.dbg /usr/lib/linuxcnc/posix/pru_decamux.dbg

--- a/debian/rt-preempt-postinst.add
+++ b/debian/rt-preempt-postinst.add
@@ -7,7 +7,7 @@ rm -f /usr/lib/linuxcnc/rt-preempt/pru_decamux.bin
 rm -f /usr/lib/linuxcnc/rt-preempt/pru_decamux.dbg
 
 # make symlinks to BBB pru_*.*
-ln -s /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/rt-preempt/pru_generic.bin
-ln -s /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/rt-preempt/pru_generic.dbg
-ln -s /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/rt-preempt/pru_decamux.bin
-ln -s /usr/lib/linuxcnc/prubin/pru_decamux.dbg /usr/lib/linuxcnc/rt-preempt/pru_decamux.dbg
+ln -sf /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/rt-preempt/pru_generic.bin
+ln -sf /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/rt-preempt/pru_generic.dbg
+ln -sf /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/rt-preempt/pru_decamux.bin
+ln -sf /usr/lib/linuxcnc/prubin/pru_decamux.dbg /usr/lib/linuxcnc/rt-preempt/pru_decamux.dbg

--- a/debian/xenomai-postinst.add
+++ b/debian/xenomai-postinst.add
@@ -7,7 +7,7 @@ rm -f /usr/lib/linuxcnc/xenomai/pru_decamux.bin
 rm -f /usr/lib/linuxcnc/xenomai/pru_decamux.dbg
 
 # make symlinks to BBB pru_*.*
-ln -s /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/xenomai/pru_generic.bin
-ln -s /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/xenomai/pru_generic.dbg
-ln -s /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/xenomai/pru_decamux.bin
-ln -s /usr/lib/linuxcnc/prubin/pru_decamux.dbg /usr/lib/linuxcnc/xenomai/pru_decamux.dbg
+ln -sf /usr/lib/linuxcnc/prubin/pru_generic.bin /usr/lib/linuxcnc/xenomai/pru_generic.bin
+ln -sf /usr/lib/linuxcnc/prubin/pru_generic.dbg /usr/lib/linuxcnc/xenomai/pru_generic.dbg
+ln -sf /usr/lib/linuxcnc/prubin/pru_decamux.bin /usr/lib/linuxcnc/xenomai/pru_decamux.bin
+ln -sf /usr/lib/linuxcnc/prubin/pru_decamux.dbg /usr/lib/linuxcnc/xenomai/pru_decamux.dbg

--- a/src/Makefile
+++ b/src/Makefile
@@ -151,10 +151,10 @@ ifeq ($(RUN_IN_PLACE)+$(BUILD_DRIVERS),yes+yes)
 		    \( 0`stat -c %u ../libexec/rtapi_app_$$f 2>/dev/null` \
 			-ne 0 -o ! -u ../libexec/rtapi_app_$$f \) \
 		&& need_setuid=1; \
-	    ln -s $(EMC2_HOME)/rtlib/prubin/pru_generic.bin ../rtlib/$$f/pru_generic.bin; \
-	    ln -s $(EMC2_HOME)/rtlib/prubin/pru_generic.dbg ../rtlib/$$f/pru_generic.dbg; \
-	    ln -s $(EMC2_HOME)/rtlib/prubin/pru_decamux.bin ../rtlib/$$f/pru_decamux.bin; \
-	    ln -s $(EMC2_HOME)/rtlib/prubin/pru_decamux.dbg ../rtlib/$$f/pru_decamux.dbg; \
+	    ln -sf $(EMC2_HOME)/rtlib/prubin/pru_generic.bin ../rtlib/$$f/pru_generic.bin; \
+	    ln -sf $(EMC2_HOME)/rtlib/prubin/pru_generic.dbg ../rtlib/$$f/pru_generic.dbg; \
+	    ln -sf $(EMC2_HOME)/rtlib/prubin/pru_decamux.bin ../rtlib/$$f/pru_decamux.bin; \
+	    ln -sf $(EMC2_HOME)/rtlib/prubin/pru_decamux.dbg ../rtlib/$$f/pru_decamux.dbg; \
 	done; \
 	test "$$need_setuid" = 1 && \
 	    $(VECHO) -n "You now need to run 'sudo make setuid' " && \


### PR DESCRIPTION
Prevents any warnings etc. when an updated package is installed
on top of an existing package which also made the symlinks.

Also forces symlink creation where a RIP is built more than once
on the same clone of a repo.

Signed-off-by: Mick <arceye@mgware.co.uk>