### PR TITLE
Tidy package names to be uniform with machinekit

### DIFF
--- a/scripts/build_source_package
+++ b/scripts/build_source_package
@@ -52,7 +52,7 @@ UPSTREAM_ID=${PKGSOURCE//[-_]/}.${PR_OR_BRANCH//[-_]/}
 VERSION="${MAJOR_MINOR_VERSION}.${TIMESTAMP}.git${SHA1SHORT}"
 
 # Final release
-RELEASE="1${UPSTREAM_ID}~1${DISTRO}"
+RELEASE="1~${DISTRO}"
 
 ###########################################################
 # Debug output


### PR DESCRIPTION
Rationalise package naming strings by removing upstream-id
which dragged in the builder details

Signed-off-by: Mick arceye@mgware.co.uk