### PR TITLE
Makefile: machinetalk protobuf interpolator linking

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1268,7 +1268,7 @@ obj-m += jplan.o
 jplan-objs := hal/jplanner/jplan.o machinetalk/build/machinetalk/protobuf/jplan.npb.o
 
 obj-m += interpolate.o
-interpolate-objs := hal/interpolator/interpolate.o
+interpolate-objs := hal/interpolator/interpolate.o machinetalk/build/machinetalk/protobuf/ros.npb.o
 
 obj-m += icomp.o
 icomp-objs := hal/icomp-example/icomp.o


### PR DESCRIPTION
see also:
https://github.com/machinekit/Machinekit-HAL/pull/27/commits/369d82ac6b86aece36ef2b86d78de54b29948c3b

and:
https://github.com/machinekit/machinekit/pull/1319/commits/de6b617c6188b7b12b9f324385eadc97da918a8a

interpolate was not properly linked yet