### PR TITLE
Remove python-gst dependency for package from Stretch and above.

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -43,7 +43,13 @@ guess_arch_from_kver() {
 }
 
 do_posix() {
-    cat control.posix.in >> control
+    ## need python-gst0.10 for Jessie, none for Stretch, Sid or Buster
+    if [ "$DISTRO_CODENAME" == "jessie" ]; then
+	cat control.posix.in >> control
+    else
+        cat control.posix-stretch.in >> control
+    fi
+    
     echo "debian/control:  added POSIX threads package" >&2
     rules_enable_threads posix
     HAVE_FLAVOR=true
@@ -51,7 +57,13 @@ do_posix() {
 
 ## cater for fact that Stretch now has it's own rt-preempt kernels
 do_rt-preempt() {
-    cat control.rt-preempt.in >> control
+    ## need python-gst0.10 for Jessie, none for Stretch, Sid or Buster
+    if [ "$DISTRO_CODENAME" == "jessie" ]; then
+	cat control.rt-preempt.in >> control
+    else
+        cat control.rt-preempt-stretch.in >> control
+    fi
+
     echo "debian/control:  added RT_PREEMPT threads package" >&2
     rules_enable_threads rt-preempt
     HAVE_FLAVOR=true
@@ -77,9 +89,14 @@ do_tcl_tk_version() {
 }
 
 do_xenomai() {
-    cat control.xenomai.in >> control
-    echo "debian/control:  added xenomai threads package for Jessie" >&2
+    ## need python-gst0.10 for Jessie, none for Stretch Sid or Buster
+    if [ "$DISTRO_CODENAME" == "jessie" ]; then
+	cat control.xenomai.in >> control
+    else
+        cat control.xenomai-stretch.in >> control
+    fi
 
+    echo "debian/control:  added xenomai threads package for Jessie" >&2
     # Be sure the -dev files only appear once
     BUILD_DEPS="${BUILD_DEPS/libxenomai-dev, /}libxenomai-dev, "
     echo "debian/control:  added Xenomai (userland) threads package" \

--- a/debian/control.posix-stretch.in
+++ b/debian/control.posix-stretch.in
@@ -1,0 +1,14 @@
+
+Package: machinekit-hal-posix
+Architecture: any
+Provides:  machinekit-hal
+Conflicts: machinekit
+Depends: ${misc:Depends},
+    python-numpy, python-vte, python-xlib, python-configobj,
+    python-zmq, python-protobuf (>= 2.4.1),
+    python-avahi, bc, procps, psmisc, module-init-tools | kmod,
+    libzmq3-dev (>= 4.0.4), libczmq-dev (>= 4.0.2), libjansson4, yapps2-runtime
+Description: HAL stack split from Machinekit
+ .
+ This package provides components and drivers that run on a non-realtime
+ (Posix) system.

--- a/debian/control.rt-preempt-stretch.in
+++ b/debian/control.rt-preempt-stretch.in
@@ -1,0 +1,13 @@
+
+Package: machinekit-hal-rt-preempt
+Architecture: any
+Provides:  machinekit-hal
+Conflicts: machinekit
+Depends: ${misc:Depends},
+    python-numpy, python-vte, python-xlib, python-configobj,
+    python-zmq, python-protobuf (>= 2.4.1),
+    python-avahi, bc, procps, psmisc, module-init-tools | kmod,
+    libzmq3-dev (>= 4.0.4), libczmq-dev (>= 4.0.2), libjansson4, yapps2-runtime
+Description: HAL stack split from machinekit
+ .
+ This package provides components and drivers that run on an RT-Preempt system.

--- a/debian/control.xenomai-stretch.in
+++ b/debian/control.xenomai-stretch.in
@@ -1,0 +1,14 @@
+
+Package: machinekit-hal-xenomai
+Architecture: any
+Provides:  machinekit-hal
+Conflicts: machinekit
+Depends: ${misc:Depends},
+    xenomai-runtime, python-numpy, python-vte, python-xlib, python-configobj,
+    python-zmq, python-protobuf (>= 2.4.1),
+    python-avahi, bc, procps, psmisc, module-init-tools | kmod,
+    libzmq3-dev (>= 4.0.4), libczmq-dev (>= 4.0.2), libjansson4, yapps2-runtime
+Description: HAL stack split from machinekit
+ .
+ This package provides components and drivers that run on a Xenomai
+ realtime system, with userspace threads.


### PR DESCRIPTION
The gst module used by gmoccapy and gscreen has been deprecated
as from Debian 9.

This is only used by those 2 GUIs to play sounds and that code is already
amended to skip this option in Stretch and above.

Signed-off-by: Mick <arceye@mgware.co.uk>