### PR TITLE
Remove compiler warnings or annotate cause where not practical

### DIFF
--- a/src/hal/lib/hal_rcomp.c
+++ b/src/hal/lib/hal_rcomp.c
@@ -301,7 +301,9 @@ int hal_ccomp_report(hal_compiled_comp_t *cc,
 
     for (i = 0; i < cc->n_pins; i++) {
 	if (report_all || RTAPI_BIT_TEST(cc->changed, i)) {
-	    const hal_pin_t *pin = cc->pin[i];
+	    // removing const from pin reduces 2 warnings to 1, but larger Q is why
+	    // so many of the inlines have inconsistent const qualifiers
+	    hal_pin_t *pin = cc->pin[i];
 	    // XXX this is not a good API
 	    // drop the fourth argument and pass only the pin
 	    // to force accessor use in the report callback

--- a/src/hal/utils/halcmd.c
+++ b/src/hal/utils/halcmd.c
@@ -880,6 +880,10 @@ static int replace_vars(char *source_str, char *dest_str, int max_chars, char **
 		}
 		if (replacement==NULL) {
                     *detail = info;
+// Compiler warnings
+// Copying a buffer plus extra formatting to a buffer of same size
+// and restricting copy size to buffer size, will always raise
+// a warning re possible truncation
                     snprintf(info, sizeof(info), "[%s]%s", sec, var);
 		    return -5;
                 }

--- a/src/hal/utils/halcmd_commands.c
+++ b/src/hal/utils/halcmd_commands.c
@@ -2020,7 +2020,9 @@ static int print_comp_entry(hal_object_ptr o, foreach_args_t *args)
 		halcmd_output(", unbound:%lds", comp->last_unbound-now);
 	    } else
 		halcmd_output(", unbound:never");
-		halcmd_output(", u1:%d u2:%d", comp->userarg1, comp->userarg2);
+	    // false indent made next line appear conditional, whereas it is actually
+	    // unnecessary because same line will be printed for all matches by L:2030
+	    // halcmd_output(", u1:%d u2:%d", comp->userarg1, comp->userarg2);
 	    break;
 	default:
 	    halcmd_output(" %-5s %s", "", state_name(comp->state));

--- a/src/libnml/inifile/inivar.cc
+++ b/src/libnml/inifile/inivar.cc
@@ -29,6 +29,10 @@
 #include "config.h"
 #include "inifile.hh"
 
+// Compiler warnings
+// Copying a string of unknown length into a fixed size buffer
+// and restricting copy size to buffer size, will always raise
+// a warning re possible truncation
 
 int main(int argc, char *argv[])
 {

--- a/src/libnml/posemath/_posemath.c
+++ b/src/libnml/posemath/_posemath.c
@@ -519,6 +519,10 @@ int pmMatZyzConvert(PmRotationMatrix const * const m, PmEulerZyz * const zyz)
     return pmErrno = 0;
 }
 
+// Compiler warnings
+// reference to fabs() and atan2() before declaration conflicts with
+// built in function
+
 int pmMatZyxConvert(PmRotationMatrix const * const m, PmEulerZyx * const zyx)
 {
     zyx->y = rtapi_atan2(-m->x.z, pmSqrt(pmSq(m->x.x) + pmSq(m->x.y)));

--- a/src/machinetalk/lib/mk_service.cc
+++ b/src/machinetalk/lib/mk_service.cc
@@ -171,8 +171,11 @@ int mk_bindsocket(mk_netopts_t *n, mk_socket_t *s)
 	    syslog_async(LOG_ERR, "bind(%s): %s\n", buf, strerror(errno));
 
 	// construct URI for mDNS announcement
-	char dsn[PATH_MAX];
-
+	// Compiler warnings
+	// Copying a string PATH_MAX length plus 4 chars into a buffer of PATH_MAX
+	// and restricting copy size to PATH_MAX, will always raise
+	// a warning re possible truncation
+	char dsn[PATH_MAX]; 
 	snprintf(dsn, sizeof(dsn), "dsn=%s", buf);
 	s->announced_uri = strdup(dsn);
     }

--- a/src/machinetalk/support/unionread.c
+++ b/src/machinetalk/support/unionread.c
@@ -57,7 +57,7 @@ bool print_container(pb_istream_t *stream)
     if (!pb_decode_varint(stream, &length)) {
 	printf("Parsing field#2 failed: %s\n", PB_GET_ERROR(stream));
     }
-    printf("submessage length=%llu\n", length);
+    printf("submessage length=%lu\n", length);  // change %llu to %lu to match uint64_t @ long unsigned int
 
 //    printf("submessage: %s NML; %s Motion\n",
 //	   is_NML_container(tag) ? "is" : "not",

--- a/src/rtapi/rtapi_compat.c
+++ b/src/rtapi/rtapi_compat.c
@@ -368,6 +368,13 @@ int check_rtapi_lib(char *name)
     return (stat(fname, &sb) == 0);
 }
 
+// NB. compiler warnings re possible data truncation or overrun
+// So long as a buffer of size PATH_MAX _plus_ extra formatting
+// is being copied into another buffer of size PATH_MAX,
+// you either restrict to size PATH_MAX and risk truncation or 
+// do not restrict and risk segfault on buffer overrun.
+// Would require too much work to remove warnings at this time.
+
 int module_path(char *result, const char *basename)
 {
     /* Find a kernel module's path */

--- a/src/rtapi/rtapi_msgd.cc
+++ b/src/rtapi/rtapi_msgd.cc
@@ -976,7 +976,9 @@ int main(int argc, char **argv)
     argv0_len = strlen(argv[0]);
     procname_len = strlen(proctitle);
     max_procname_len = (argv0_len > procname_len) ? (procname_len) : (argv0_len);
-
+    // Compiler warnings.
+    // `specified bound depends on the length of the source argument [-Wstringop-overflow=]`
+    // which isn't actually correct since it is limited to size of smallest string by preceding lines.
     strncpy(argv[0], proctitle, max_procname_len);
     memset(&argv[0][max_procname_len], '\0', argv0_len - max_procname_len);
 


### PR DESCRIPTION
Using gcc / g++ 8.2.0-3, which is becoming very picky.

Signed-off-by: Mick <arceye@mgware.co.uk>