### PR TITLE
src/hal/sample_channel: add sample_channel component

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -476,6 +476,7 @@ HEADERS := \
     machinetalk/build/machinetalk/protobuf/config.pb.h \
     machinetalk/build/machinetalk/protobuf/firmware.npb.h \
     machinetalk/build/machinetalk/protobuf/jplan.pb.h \
+    machinetalk/build/machinetalk/protobuf/sample.pb.h \
     machinetalk/build/machinetalk/protobuf/message.npb.h \
     machinetalk/build/machinetalk/protobuf/motcmds.pb.h \
     machinetalk/build/machinetalk/protobuf/object.npb.h \
@@ -500,6 +501,7 @@ HEADERS := \
     machinetalk/build/machinetalk/protobuf/config.npb.h \
     machinetalk/build/machinetalk/protobuf/emcclass.pb.h \
     machinetalk/build/machinetalk/protobuf/jplan.npb.h \
+    machinetalk/build/machinetalk/protobuf/sample.npb.h \
     machinetalk/build/machinetalk/protobuf/log.pb.h \
     machinetalk/build/machinetalk/protobuf/motcmds.npb.h \
     machinetalk/build/machinetalk/protobuf/nanopb.pb.h \
@@ -1135,6 +1137,9 @@ scope_rt-objs := hal/utils/scope_rt.o $(MATHSTUB)
 obj-m += jplan.o
 jplan-objs := hal/jplanner/jplan.o machinetalk/build/machinetalk/protobuf/jplan.npb.o
 
+obj-m += sample_channel_pb.o
+sample_channel_pb-objs := hal/sample_channel/sample_channel_pb.o machinetalk/build/machinetalk/protobuf/sample.npb.o
+
 obj-m += interpolate.o
 interpolate-objs := hal/interpolator/interpolate.o machinetalk/build/machinetalk/protobuf/ros.npb.o
 
@@ -1401,6 +1406,7 @@ $(RTLIBDIR)/hal_gm$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(hal_gm-objs))
 $(RTLIBDIR)/tp$(MODULE_EXT): $(addprefix $(OBJDIR)/,$(tp-objs))
 $(RTLIBDIR)/ufdemo$(MODULE_EXT):	$(addprefix $(OBJDIR)/,$(ufdemo-objs))
 $(RTLIBDIR)/jplan$(MODULE_EXT):		$(addprefix $(OBJDIR)/,$(jplan-objs))
+$(RTLIBDIR)/sample_channel_pb$(MODULE_EXT):		$(addprefix $(OBJDIR)/,$(sample_channel_pb-objs))
 $(RTLIBDIR)/interpolate$(MODULE_EXT):	$(addprefix $(OBJDIR)/,$(interpolate-objs))
 $(RTLIBDIR)/icomp$(MODULE_EXT):		$(addprefix $(OBJDIR)/,$(icomp-objs))
 $(RTLIBDIR)/lutn-demo$(MODULE_EXT):	$(addprefix $(OBJDIR)/,$(lutn-demo-objs))

--- a/src/hal/sample_channel/sample_channel.hal
+++ b/src/hal/sample_channel/sample_channel.hal
@@ -1,0 +1,35 @@
+#  nanopb protobuf descriptors needed for protobuf de/encoding in RT
+loadrt pbmsgs
+
+# signal generator so we have something to see
+loadrt siggen
+
+# create sample_channel instance with pins and ring
+# give the type of pins to be created with: samples=bfusUSf
+# tell max cycles the ring should be able to contain by: cycles=100
+newinst sample_channel_pb sampler --- samples=bfusUSf cycles=100
+
+# create fast (1 ms) thread
+newthread fast 1000000 fp
+# create slow (0.5 second) thread so we can inspect with a python reader on the ring
+newthread slow 500000000 fp
+
+# add function to thread
+addf sampler.record_sample slow
+addf siggen.0.update fast
+
+setp sampler.in-bit.1 1
+setp sampler.in-flt.1 3.14159265359
+setp sampler.in-u32.1 123456
+setp sampler.in-s32.1 -654321
+
+#connect sine signal to 2nd float pin
+net sine siggen.0.sine sampler.in-flt.2
+
+#set low frequency so we can see some changes in the samples
+setp siggen.0.frequency 0.125
+
+# this will record the pin sample to the ring each time the function is called
+setp sampler.record 1
+
+start

--- a/src/hal/sample_channel/sample_channel_pb.c
+++ b/src/hal/sample_channel/sample_channel_pb.c
@@ -1,0 +1,502 @@
+/*****************************************************************************
+
+    Instantiatiable recorder with configurable pins
+    
+    This recorder puts pin values with a timestamp in a protobuf encoded message
+    in a HAL ringbuffer.
+    
+    See also:
+    * sample_channel.hal
+    * show_sample.py
+    * sample.proto
+    
+    Usage:
+    newinst sample_channel_pb sampler --- samples=bbfusUS cycles=10
+    
+    This will create an instance "sampler" with pins and a ring.
+    The ring can contain at least 10 cycles of the record_sample.funct
+    Pins:
+    * 2 bits
+    * 1 float
+    * 1 unsigned 32
+    * 1 signed 32
+    * 1 unsigned 64
+    * 1 signed 64
+    Ring:
+    * sampler.ring
+
+    Author: Bas de Bruijn <bdebruijnATluminizeDOTnl>
+    License: GPL Version 2
+
+    Copyright (c) 2019 All rights reserved.
+    
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of version 2 of the GNU General
+    Public License as published by the Free Software Foundation.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    
+    You should have received a copy of the GNU General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+
+    THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
+    ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE
+    TO RELY ON SOFTWARE ALONE FOR SAFETY.  Any machinery capable of
+    harming persons must have provisions for completely removing power
+    from all motors, etc, before persons enter any danger area.  All
+    machinery must be designed to comply with local and national safety
+    codes, and the authors of this software can not, and do not, take
+    any responsibility for such compliance.
+
+*****************************************************************************/
+
+
+#include "rtapi.h"
+#include "rtapi_app.h"
+#include "rtapi_string.h"
+#include "hal.h"
+#include "hal_priv.h"
+#include "hal_ring.h"
+
+#include <stdlib.h>  /* for atoi() */
+#include <machinetalk/nanopb/pb_encode.h>
+#include <machinetalk/build/machinetalk/protobuf/sample.npb.h>
+
+MODULE_AUTHOR("Bas de Bruijn");
+MODULE_DESCRIPTION("Instantiable configurable recorder to a HAL ring");
+MODULE_LICENSE("GPLv2");
+
+RTAPI_TAG(HAL,HC_INSTANTIABLE);
+
+#define MAX_PINS    64        // maximum amount of pins, see also sample.proto
+#define RB_HEADROOM 1.2       // ringbuffer size overallocation
+
+static int comp_id;
+static char *compname = "sample_channel_pb";
+
+struct inst_data{
+    // pins
+    hal_bit_t		*record;			// pin: when high -> start recording
+    hal_data_u		*pins_in[MAX_PINS];	// pin: array of sample values
+    hal_u32_t 		*send_fail;		    // error counter on the send side
+    hal_u32_t       *dropped;           // dropped sampled due to full ring;
+  
+    // the ringbuffer
+    ringbuffer_t    sample_ring;
+    size_t          sample_size;
+
+    // other instance data
+    char            samples_cfg[MAX_PINS];      // the samples config string
+    int             nr_samples;                 // the number of samples
+    int             cycles;                     // amount of cycles
+
+    const char      *name[HAL_NAME_LEN + 1];    // the name of this instance
+};
+
+// copied from pbring.c
+enum {
+    NBP_SIZE_FAIL   = -100,
+    NBP_ENCODE_FAIL = -101,
+    NBP_DECODE_FAIL = -102,
+    RB_RESERVE_FAIL = -103,
+    RB_WRITE_FAIL   = -104,
+} rtmsg_errors_t;
+
+
+// copied from pbring.c and adapted where needed
+//
+// encode message struct in msg according to 'fields', and send off via rb
+// return 0 on success or < 0 on failure; see rtmsg_errors_t
+//
+static int npb_send_msg(const void *msg, const pb_field_t *fields,
+			            ringbuffer_t *rb, const hal_funct_args_t *fa)
+{
+    void *buffer;
+    int retval;
+    size_t size;
+
+    // determine size
+    pb_ostream_t sstream = PB_OSTREAM_SIZING;
+    if (!pb_encode(&sstream, fields,  msg)) {
+	    rtapi_print_msg(RTAPI_MSG_ERR,
+			"%s: sizing pb_encode(): %s written=%zu\n",
+			fa_funct_name(fa), PB_GET_ERROR(&sstream), sstream.bytes_written);
+	    return NBP_SIZE_FAIL;
+    }
+    size = sstream.bytes_written;
+
+    // preallocate memory in ringbuffer
+    if ((retval = record_write_begin(rb, (void **)&buffer, size)) != 0) {
+	    rtapi_print_msg(RTAPI_MSG_ERR,
+            "%s: record_write_begin(%zu) failed: %d\n", fa_funct_name(fa),
+            size, retval);
+	    return RB_RESERVE_FAIL;
+    }
+
+    // zero-copy encode directly into ringbuffer
+    pb_ostream_t rstream = pb_ostream_from_buffer(buffer, size);
+    if (!pb_encode(&rstream, fields,  msg)) {
+	    rtapi_print_msg(RTAPI_MSG_ERR,
+			"%s: pb_encode failed: %s, size=%zu written=%zu\n",
+            fa_funct_name(fa), PB_GET_ERROR(&rstream), size,
+            rstream.bytes_written);
+	    return NBP_ENCODE_FAIL;
+    }
+
+    // send it off
+    if ((retval = record_write_end(rb, buffer, rstream.bytes_written))) {
+	    rtapi_print_msg(RTAPI_MSG_ERR,
+			"%s: record_write_end(%zu) failed: %d\n", fa_funct_name(fa),
+            size, retval);
+	    return RB_WRITE_FAIL;
+    }
+    return 0;
+}
+
+
+static int record_sample(void *arg, const hal_funct_args_t *fa)
+{
+    int i=0;
+    int retval;
+    // get hold of the instance
+    struct inst_data *ip = arg;
+    if (*(ip->record) == true) {
+        // read the values of the pins ip->pins_in[i], up to nr_samples
+        // depending on the type, put value in ip->sample->arr_sample
+        // pins are made in order of the config string
+        for (i = 0; i < ip->nr_samples; i++) {
+            machinetalk_Sample tx_sample = machinetalk_Sample_init_zero;
+            tx_sample.has_timestamp = true;
+            tx_sample.timestamp = fa_thread_start_time(fa);
+            switch (ip->samples_cfg[i])
+            {
+            case 'b':
+            case 'B':
+                tx_sample.has_v_bool = true;
+                tx_sample.v_bool = get_bit_value(ip->pins_in[i]);
+                break;
+            case 'f':
+            case 'F':
+                tx_sample.has_v_double = true;
+                tx_sample.v_double = get_float_value(ip->pins_in[i]);
+                break;
+            case 'u':
+                tx_sample.has_v_uint32 = true;
+                tx_sample.v_uint32 = get_u32_value(ip->pins_in[i]);
+                break;
+            case 's':
+                tx_sample.has_v_int32 = true;
+                tx_sample.v_int32 = get_s32_value(ip->pins_in[i]);
+                break;
+            case 'U':
+                tx_sample.has_v_uint64 = true;
+                tx_sample.v_uint64 = get_u64_value(ip->pins_in[i]);
+                break;
+            case 'S':
+                tx_sample.has_v_int64 = true;
+                tx_sample.v_int64 = get_s64_value(ip->pins_in[i]);
+                break;
+            case HAL_TYPE_MAX:
+            case HAL_TYPE_UNSPECIFIED:
+                // should not happen, already checked
+                break;
+            }
+            // copied from pbring.c and adapted as needed
+            // sample message has been filled and can now be sent off.
+            if ((retval = npb_send_msg(&tx_sample, machinetalk_Sample_fields,
+                        &ip->sample_ring, fa))) {
+                    rtapi_print_msg(RTAPI_MSG_ERR,
+                    "%s: sending of message failed = %d", compname, retval);
+                *(ip->send_fail) +=1;
+            } 
+        }
+    }
+    return 0;
+}
+
+
+static int calc_sampling_config(struct inst_data *ip)
+{
+    int i=0, validchar=0;
+    char character;
+    // track the amount of valid characters
+    validchar = 0;
+    for (i = 0; (character = ip->samples_cfg[i]); i++) {
+        switch (character) {
+            case 'b':
+            case 'B':
+                validchar++;
+                break;
+            case 'f':
+            case 'F':
+                validchar++;
+                break;
+            case 'u':
+                validchar++;
+                break;
+            case 's':
+                validchar++;
+                break;
+            case 'U':
+                validchar++;
+                break;
+            case 'S':
+                validchar++;
+                break;
+            default:
+                rtapi_print_msg(RTAPI_MSG_ERR, "invalid character in "
+                        "\"samples=\" string. Needs to be b,f,s,u,S or U\n");
+                hal_exit(comp_id);
+                return -1;
+        }
+        ip->nr_samples = validchar;
+    }
+    return 0;
+}
+
+
+static int export_pins(struct inst_data *ip, const char *name)
+{
+    int retval=0, i=0, idx=0;
+    int indexes[6] = {0,0,0,0,0,0};
+    char *pin_type;
+    char character = '-';
+    hal_type_t type = HAL_TYPE_UNSPECIFIED;
+
+    // some debug output
+    for (i = 0; (i < ip->nr_samples); i++) {
+        hal_print_msg(RTAPI_MSG_DBG,"%s: ip->samples_cfg[%d] = %c",
+            compname, i, ip->samples_cfg[i]);
+    }
+
+    // traverse ip->samples_cfg array
+    // create and name the pin depending on the type and consecutive number
+    for (i = 0; i < ip->nr_samples; i++) {
+
+        character = ip->samples_cfg[i];
+        hal_print_msg(RTAPI_MSG_DBG,"%s: ip->samples_cfg[%d] = %c", compname,
+            i, character);
+        switch (character) {
+            case 'b':
+            case 'B':
+                pin_type = "bit";
+                type = HAL_BIT;
+                idx = 0;
+                break;
+            case 'f':
+            case 'F':
+                pin_type = "flt";
+                type = HAL_FLOAT;
+                idx = 1;
+                break;
+            case 'u':
+                pin_type = "u32";
+                type = HAL_U32;
+                idx = 2;
+                break;
+            case 's':
+                pin_type = "s32";
+                type = HAL_S32;
+                idx = 3;
+                break;
+            case 'U':
+                pin_type = "u64";
+                type = HAL_U64;
+                idx = 4;
+                break;
+            case 'S':
+                pin_type = "s64";
+                type = HAL_S64;
+                idx = 5;
+                break;
+            case '-':
+            default:
+                type = HAL_TYPE_UNSPECIFIED;
+                hal_print_msg(RTAPI_MSG_ERR,
+                    "%s: invalid type '%c' for pin %d\n", compname, type, i);
+                hal_exit(comp_id);
+                return -1;
+        }
+        indexes[idx]++;
+        hal_print_msg(RTAPI_MSG_DBG,
+            "%s: new pin name %s.in%d-%s", compname, name, indexes[idx],
+                pin_type);
+        // create sample pins
+        if ((retval = hal_pin_newf(type, HAL_IN, (void **) &ip->pins_in[i],
+                comp_id, "%s.in-%s.%d", name, pin_type, indexes[idx])) < 0) {
+            return retval;
+        }
+	}
+    // create misc pins
+    if (((retval = hal_pin_bit_newf(HAL_IN, &(ip->record), comp_id,
+				    "%s.record", name))) ||
+        ((retval = hal_pin_u32_newf(HAL_IN, &(ip->dropped), comp_id,
+				    "%s.dropped", name))) ||
+    	((retval = hal_pin_u32_newf(HAL_OUT, &(ip->send_fail), comp_id,
+				    "%s.send-fail", name)))) {
+    	return retval;
+    }
+    ip->dropped = 0;
+    return 0;
+}
+
+
+static int create_ring(struct inst_data *ip, const char *name)
+{
+    int retval=0;
+    // determine the required size of the ringbuffer
+    size_t sample_size = sizeof(machinetalk_Sample);
+    size_t rbsize = (sample_size * ip->cycles) * RB_HEADROOM;
+
+    // create the ring queue
+    if ((retval = hal_ring_newf(rbsize, sample_size, RINGTYPE_RECORD,
+			"%s.ring", name)) < 0) {
+	    hal_print_msg(RTAPI_MSG_ERR,
+		    "%s: failed to create new ring '%s.ring': %d\n", compname,
+            name, retval);
+	    return retval;
+    }
+
+    // attach to the command ringbuffer '<instancename>.ring' if it exists
+    // must be record mode
+    unsigned flags;
+    if (!hal_ring_attachf(&(ip->sample_ring), &flags,  "%s.ring", name))
+    {
+		if ((flags & RINGTYPE_MASK) != RINGTYPE_RECORD) {
+		    HALERR("ring %s.ring not a record mode ring: mode=%d", name,
+            flags & RINGTYPE_MASK);
+		    return -EINVAL;
+		}
+    } 
+    else
+    {
+		HALERR("ring %s.ring does not exist", name);
+		return -EINVAL;
+    }
+    return 0;
+}
+
+
+static int instantiate_sample_channel_pb(const int argc, const char **argv)
+{
+    struct inst_data *ip;
+    const char *name = argv[1];
+    int inst_id=0, i=0, j=0, cycles=0;
+    char samples[MAX_PINS];
+    bool has_samples_string=false, has_cycles_string=false;
+
+    // parse arguments
+    for(i = 2; i < argc; i++)
+	{
+        const char *argument = argv[i];
+        hal_print_msg(RTAPI_MSG_ERR,
+            "%s: %s: argument %d = %s\n", compname, name, i, argument);
+        if((strstr(argument, "samples=")) != NULL)
+        {
+            strcpy(samples, &argument[8]);
+            has_samples_string = true;
+        }
+        else if((strstr(argument, "cycles=")) != NULL)
+        {
+            cycles = atoi(&argument[7]);
+            hal_print_msg(RTAPI_MSG_DBG, "cycles = %d", cycles);
+            has_cycles_string = true;
+        }
+	}
+    // exit if no samples
+    if (!has_samples_string)
+    {
+        hal_print_msg(RTAPI_MSG_ERR,
+            "%s: %s: ERROR: sample pins must be specified\n",
+            compname,
+            name);
+        return -1;
+    }
+    // exit if no cycles
+    if (!has_cycles_string)
+    {
+        hal_print_msg(RTAPI_MSG_ERR,
+            "%s: %s: ERROR: cycles (nr of samples on the ring) is hot given\n",
+            compname, name);
+        return -1;
+    }
+    // check if samples string is not void
+    if (samples[0] == '\0')
+    {
+	    hal_print_msg(RTAPI_MSG_ERR,
+            "%s: %s: ERROR: sample pins string is void\n", compname, name);
+	    return -1;
+	}
+    // instantiate component
+    if ((inst_id = hal_inst_create(name, comp_id,
+				  sizeof(struct inst_data),
+                  (void **)&ip)) < 0)
+	    return -1;
+
+    strcpy(ip->samples_cfg, samples);
+    ip->cycles = cycles;
+    hal_print_msg(RTAPI_MSG_DBG,"%s: %s: ip->samples_cfg set to %s",
+        compname, name, ip->samples_cfg);
+    // calculate amount of pins, types, values in instance data
+    if (calc_sampling_config(ip) < 0){
+	    hal_print_msg(RTAPI_MSG_ERR,
+            "%s: %s: ERROR: setup sampling configuration failed\n",
+            compname, name);
+	    return -1;
+    }
+    hal_print_msg(RTAPI_MSG_DBG,
+        "%s: %s: ip->nr_samples set to %d", compname, name, ip->nr_samples);
+    for (j = 0; (j < ip->nr_samples); j++) {
+        hal_print_msg(RTAPI_MSG_DBG,
+            "%s: %s: ip->samples_cfg[%d] = %c", compname, name, j,
+            ip->samples_cfg[j]);
+    }
+    hal_print_msg(RTAPI_MSG_DBG,
+        "%s: %s: ip->samples_cfg is %s", compname, name, ip->samples_cfg);
+    // create the ring
+	if ( create_ring(ip, name) < 0 ) {
+	    hal_print_msg(RTAPI_MSG_ERR,
+			"%s: %s: ERROR: creation of ring failed for instance \n",
+            compname, name);
+	    return -1;
+	}
+    hal_print_msg(RTAPI_MSG_DBG,
+        "%s: %s: ip->samples_cfg is %s", compname, name, ip->samples_cfg);
+    // export pins
+	if ( export_pins(ip, name) < 0 ) {
+	    hal_print_msg(RTAPI_MSG_ERR,
+			"%s: %s: ERROR: export of pins failed for instance \n",
+            compname, name);
+	    return -1;
+	}
+    // export the function for using it on the thread
+    hal_export_xfunct_args_t xfunct_args = {
+        .type = FS_XTHREADFUNC,
+        .funct.x = record_sample,
+        .arg = ip,
+        .uses_fp = 0,
+        .reentrant = 0,
+        .owner_id = inst_id
+    };
+    return hal_export_xfunctf(&xfunct_args, "%s.record_sample", name);
+}
+
+
+// entry point creating this instance
+int rtapi_app_main(void)
+{
+    comp_id = hal_xinit(TYPE_RT, 0, 0,
+        (hal_constructor_t)instantiate_sample_channel_pb, NULL, compname);
+    if (comp_id < 0) return comp_id;
+    hal_ready(comp_id);
+    return 0;
+}
+
+
+void rtapi_app_exit(void)
+{
+    hal_exit(comp_id);
+}

--- a/src/hal/sample_channel/sample_channel_pb.c
+++ b/src/hal/sample_channel/sample_channel_pb.c
@@ -199,10 +199,6 @@ static int record_sample(void *arg, const hal_funct_args_t *fa)
                 tx_sample.has_v_int64 = true;
                 tx_sample.v_int64 = get_s64_value(ip->pins_in[i]);
                 break;
-            case HAL_TYPE_MAX:
-            case HAL_TYPE_UNSPECIFIED:
-                // should not happen, already checked
-                break;
             }
             // copied from pbring.c and adapted as needed
             // sample message has been filled and can now be sent off.

--- a/src/hal/sample_channel/show_hal_sample.py
+++ b/src/hal/sample_channel/show_hal_sample.py
@@ -1,0 +1,56 @@
+# purpose, get and inspect samples from sample channel component
+# prerequisits:
+#
+# terminal 1
+# halrun -I sample_channel.hal
+#
+# terminal 2
+# python2 show_hal_sample.py
+#
+# change pin values in hal in terminal 1
+
+import os, time
+from machinekit import hal
+from machinetalk.protobuf.sample_pb2 import Sample
+from machinetalk.protobuf.types_pb2 import *
+
+# provide the name to attach to
+name = "sampler.ring"
+sample = 0
+try:
+    # attach to existing ring
+    r = hal.Ring(name)
+    while True:
+        # inspect the ring:
+        for i in r:
+            sample += 1
+            print("Sample :%i" % sample)
+            b = i.tobytes()
+            s = Sample()
+            s.ParseFromString(b)
+            if (s.HasField("v_bool") == True):
+                v = s.v_bool
+                t = "bit"
+            if (s.HasField("v_double") == True):
+                v = s.v_double
+                t = "flt"
+            if (s.HasField("v_uint32") == True):
+                v = s.v_uint32
+                t = "u32"
+            if (s.HasField("v_int32") == True):
+                v = s.v_int32
+                t = "s32"
+            if (s.HasField("v_uint64") == True):
+                v = s.v_uint64
+                t = "u64"
+            if (s.HasField("v_int64") == True):
+                v = s.v_int64
+                t = "s64"
+            # print out something meaningfull
+            print("time: %s\n%s -> %s" % (s.timestamp, t, v))
+            # consume the sample
+            r.shift()
+        time.sleep(0.01)
+
+except NameError as e:
+    print(e)

--- a/src/machinetalk/msgcomponents/Submakefile
+++ b/src/machinetalk/msgcomponents/Submakefile
@@ -25,6 +25,7 @@ pbmsgs-objs := \
 	$(PBGEN)/$(NAMESPACEDIR)/preview.npb.o \
 	$(PBGEN)/$(NAMESPACEDIR)/status.npb.o \
 	$(PBGEN)/$(NAMESPACEDIR)/ros.npb.o \
+	$(PBGEN)/$(NAMESPACEDIR)/sample.npb.o \
 	$(PBGEN)/$(NAMESPACEDIR)/jplan.npb.o \
 	$(PBGEN)/$(NAMESPACEDIR)/value.npb.o
 

--- a/src/machinetalk/msgcomponents/pbmsgs.c
+++ b/src/machinetalk/msgcomponents/pbmsgs.c
@@ -70,19 +70,23 @@ PB_DESCRIPTOR(MotionStatus);
 PB_DESCRIPTOR(RTAPI_Message);
 PB_DESCRIPTOR(RTAPICommand);
 PB_DESCRIPTOR(LogMessage);
+PB_DESCRIPTOR(Value);
 /* PB_DESCRIPTOR(Test1); */
 /* PB_DESCRIPTOR(Test2); */
 /* PB_DESCRIPTOR(Test3); */
 
 // jplan messages
-PB_DESCRIPTOR(JplanJoint)
-PB_DESCRIPTOR(JplanCommand)
+PB_DESCRIPTOR(JplanJoint);
+PB_DESCRIPTOR(JplanCommand);
 
 //ros messages
-PB_DESCRIPTOR(JointTrajectoryPoint)
-PB_DESCRIPTOR(JointTrajectory)
-PB_DESCRIPTOR(Header)
-PB_DESCRIPTOR(Time)
+PB_DESCRIPTOR(JointTrajectoryPoint);
+PB_DESCRIPTOR(JointTrajectory);
+PB_DESCRIPTOR(Header);
+PB_DESCRIPTOR(Time);
+
+// sample stream message
+PB_DESCRIPTOR(Sample);
 
 // this likely supersedes the above exports, as it
 // contains a superset of pb_<message>_fields
@@ -103,6 +107,7 @@ msginfo_t msginfo[] = {
     VALUE_MESSAGES	   \
     JPLAN_MESSAGES         \
     ROS_MESSAGES           \
+    SAMPLE_MESSAGES        \
     PB_MSGINFO_DELIMITER
 };
 

--- a/src/machinetalk/msgcomponents/pbmsgs.h
+++ b/src/machinetalk/msgcomponents/pbmsgs.h
@@ -32,6 +32,7 @@ typedef struct {
 #include <machinetalk/protobuf/test.npb.h>
 #include <machinetalk/protobuf/jplan.npb.h>
 #include <machinetalk/protobuf/ros.npb.h>
+#include <machinetalk/protobuf/sample.npb.h>
  
 
 #endif // _PBMSGS_H

--- a/src/machinetalk/proto/src/machinetalk/protobuf/sample.proto
+++ b/src/machinetalk/proto/src/machinetalk/protobuf/sample.proto
@@ -1,0 +1,27 @@
+syntax = "proto2";
+package machinetalk;
+
+// This message contains a Sample.
+// A sample is a value of a type.
+// A sample can contain a timestamp
+
+// see README.msgid
+// msgid base: 360
+
+import "machinetalk/protobuf/nanopb.proto";
+import "machinetalk/protobuf/value.proto";
+
+
+message Sample {
+    option (nanopb_msgopt).msgid = 361;
+
+    optional fixed64  timestamp = 1;
+    optional bytes    v_bytes   = 2;
+    optional sfixed32 v_int32   = 3;
+    optional sfixed64 v_int64   = 4;
+    optional fixed32  v_uint32  = 5;
+    optional fixed64  v_uint64  = 6;
+    optional double   v_double  = 7;
+    optional string   v_string  = 8 [(nanopb).max_size = 41];
+    optional bool     v_bool    = 9;
+}


### PR DESCRIPTION
This PR introduces an instantiatiable component called "sample channel" which samples HAL pins, encodes them in a protobuf "Sample" message and puts those values in a HAL ring.
The userland side can connect to the HAL ring, get the records, and decode the Sample message. Example python script shows how.