### PR TITLE
Update package deps

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -181,12 +181,26 @@ HAVE_KTHREADS_FLAVOR=false
 # Determine tcl/tk version
 do_tcl_tk_version "$TCL_TK_VER"
 
+## situation at 20092018
+## python-gst1.0 backported to Jessie + Stretch
+## python-gtksourceview2 not available for Buster but is for Sid, meaning gladevcp widgets keep working.
+## python-pil and python-pil.imagegtk active for Sid replacing python-imaging and python-imaging-tk
+## however selecting python-imaging and python-imaging-tk in Stretch actually
+## results in python-pil and python-pil.imagegtk being installed, so will probably completely backport soon.
 
-# delete old files
-rm -f machinekit-hal-{rtai,xenomai}-kernel-*.install
+## Keep individual control files, so they can easily be amended as things change
 
 # copy base templates into place
-cp control.in control
+if [ "$DISTRO_CODENAME" == "stretch" ]; then
+    cp control.stretch.in control
+elif [ "$DISTRO_CODENAME" == "buster" ]; then
+    cp control.buster.in control
+elif [ "$DISTRO_CODENAME" == "sid" ]; then
+    cp control.sid.in control
+else  # Jessie
+    cp control.in control
+fi
+
 echo "debian/control:  copied base template" >&2
 
 cp postinst.in machinekit-hal-posix.postinst

--- a/debian/control.buster.in
+++ b/debian/control.buster.in
@@ -1,4 +1,4 @@
-Source: machinekit
+Source: machinekit-hal
 Section: misc
 Priority: extra
 Maintainer: John Morris <john@dovetail-automata.com>
@@ -39,7 +39,7 @@ Standards-Version: 2.1.0
 # alternate front-ends for machinekit
 #########################################################################
 
-Package: machinekit
+Package: machinekit-hal
 Breaks: linuxcnc
 Replaces: linuxcnc
 Architecture: any

--- a/debian/control.buster.in
+++ b/debian/control.buster.in
@@ -46,7 +46,7 @@ Architecture: any
 Depends: ${shlibs:Depends}, machinekit-rt-threads, tcl8.6, tk8.6,
     bwidget (>= 1.7), libtk-img (>=1.13),
     ${python:Depends}, ${misc:Depends},
-    python-tk, python-imaging, python-imaging-tk,
+    python-tk, python-pil, python-pil.imagetk,
     python-gnome2, python-glade2,
     python-numpy,
     python-vte, python-xlib, python-gtkglext1, python-configobj,

--- a/debian/control.sid.in
+++ b/debian/control.sid.in
@@ -1,4 +1,4 @@
-Source: machinekit
+Source: machinekit-hal
 Section: misc
 Priority: extra
 Maintainer: John Morris <john@dovetail-automata.com>
@@ -39,7 +39,7 @@ Standards-Version: 2.1.0
 # alternate front-ends for machinekit
 #########################################################################
 
-Package: machinekit
+Package: machinekit-hal
 Breaks: linuxcnc
 Replaces: linuxcnc
 Architecture: any

--- a/debian/control.stretch.in
+++ b/debian/control.stretch.in
@@ -1,4 +1,4 @@
-Source: machinekit
+Source: machinekit-hal
 Section: misc
 Priority: extra
 Maintainer: John Morris <john@dovetail-automata.com>
@@ -39,7 +39,7 @@ Standards-Version: 2.1.0
 # alternate front-ends for machinekit
 #########################################################################
 
-Package: machinekit
+Package: machinekit-hal
 Breaks: linuxcnc
 Replaces: linuxcnc
 Architecture: any

--- a/debian/control.stretch.in
+++ b/debian/control.stretch.in
@@ -46,7 +46,7 @@ Architecture: any
 Depends: ${shlibs:Depends}, machinekit-rt-threads, tcl8.6, tk8.6,
     bwidget (>= 1.7), libtk-img (>=1.13),
     ${python:Depends}, ${misc:Depends},
-    python-tk, python-imaging, python-imaging-tk,
+    python-tk, python-pil, python-pil.imagetk,
     python-gnome2, python-glade2,
     python-numpy, python-gtksourceview2,
     python-vte, python-xlib, python-gtkglext1, python-configobj,

--- a/src/machinetalk/haltalk/Submakefile
+++ b/src/machinetalk/haltalk/Submakefile
@@ -20,7 +20,7 @@ HALTALK_LDFLAGS := \
 	$(CZMQ_LIBS) 		\
 	$(JANSSON_LIBS) 	\
 	$(AVAHI_LIBS) 	\
-	-lstdc++ -lm
+	-lstdc++ -lm -lzmq
 
 $(call TOOBJSDEPS, $(HALTALK_SRCS)) : EXTRAFLAGS += $(HALTALK_CXXFLAGS)
 

--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -375,10 +375,10 @@ $(call TOOBJSDEPS, $(RTAPI_MSGD_SRCS)): \
 	../lib/liblinuxcncshm.so \
 	../lib/liblinuxcncini.so \
 	../lib/libmtalk.so.0 \
-	../lib/libmachinetalk-pb2++.so
+	../lib/libmachinetalk-pb2++.so 
 	$(ECHO) Linking $(notdir $@)
 	@mkdir -p $(dir $@)
-	$(Q)$(CC)  $(LDFLAGS) -o $@ $^ $(RTAPI_MSGD_LDFLAGS) -lrt
+	$(Q)$(CC)  $(LDFLAGS) -o $@ $^ $(RTAPI_MSGD_LDFLAGS) -lrt -lzmq
 
 USERSRCS += $(RTAPI_MSGD_SRCS)
 TARGETS += ../libexec/rtapi_msgd


### PR DESCRIPTION
Backports of python-gst, python-pil etc are changing the deps for Stretch and above.

Reinstate distro checks clobbered by cherry-pick of machinekit commits

Add specific -lzmq to CFLAGS to prevent DSO errors in later distros.

These errors occur with later compilers where despite linkage to a
lib, it is not sequenced to the liking of the compiler and throws
unknown symbol errors.

Has been fixed for comp too in upcoming commit which is part of the
single-module-dir work, but this will get the packages to build
on later compilers.
