### PR TITLE
Remove surplus deps carried over from machinekit

### DIFF
--- a/debian/control.posix-stretch.in
+++ b/debian/control.posix-stretch.in
@@ -4,8 +4,8 @@ Architecture: any
 Provides:  machinekit-hal
 Conflicts: machinekit
 Depends: ${misc:Depends},
-    python-numpy, python-vte, python-xlib, python-configobj,
-    python-zmq, python-protobuf (>= 2.4.1), python-gst1.0,
+    python-numpy, python-xlib, python-configobj,
+    python-zmq, python-protobuf (>= 2.4.1),
     python-avahi, bc, procps, psmisc, module-init-tools | kmod,
     libzmq3-dev (>= 4.0.4), libczmq-dev (>= 4.0.2), libjansson4, yapps2-runtime, cgroup-tools, uuid-runtime
 Description: HAL stack split from Machinekit

--- a/debian/control.posix.in
+++ b/debian/control.posix.in
@@ -4,8 +4,8 @@ Architecture: any
 Provides:  machinekit-hal
 Conflicts: machinekit
 Depends: ${misc:Depends},
-    python-numpy, python-vte, python-xlib, python-configobj,
-    python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
+    python-numpy, python-xlib, python-configobj,
+    python-zmq, python-protobuf (>= 2.4.1),
     python-avahi, bc, procps, psmisc, module-init-tools | kmod,
     libzmq3-dev (>= 4.0.4), libczmq-dev (>= 4.0.2), libjansson4, yapps2-runtime, cgroup-tools, uuid-runtime
 Description: HAL stack split from Machinekit

--- a/debian/control.rt-preempt-stretch.in
+++ b/debian/control.rt-preempt-stretch.in
@@ -4,8 +4,8 @@ Architecture: any
 Provides:  machinekit-hal
 Conflicts: machinekit
 Depends: ${misc:Depends},
-    python-numpy, python-vte, python-xlib, python-configobj,
-    python-zmq, python-protobuf (>= 2.4.1), python-gst1.0,
+    python-numpy, python-xlib, python-configobj,
+    python-zmq, python-protobuf (>= 2.4.1), 
     python-avahi, bc, procps, psmisc, module-init-tools | kmod,
     libzmq3-dev (>= 4.0.4), libczmq-dev (>= 4.0.2), libjansson4, yapps2-runtime, cgroup-tools, uuid-runtime
 Description: HAL stack split from machinekit

--- a/debian/control.rt-preempt.in
+++ b/debian/control.rt-preempt.in
@@ -4,8 +4,8 @@ Architecture: any
 Provides:  machinekit-hal
 Conflicts: machinekit
 Depends: ${misc:Depends},
-    python-numpy, python-vte, python-xlib, python-configobj,
-    python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
+    python-numpy, python-xlib, python-configobj,
+    python-zmq, python-protobuf (>= 2.4.1),
     python-avahi, bc, procps, psmisc, module-init-tools | kmod,
     libzmq3-dev (>= 4.0.4), libczmq-dev (>= 4.0.2), libjansson4, yapps2-runtime, cgroup-tools, uuid-runtime
 Description: HAL stack split from machinekit

--- a/debian/control.xenomai-stretch.in
+++ b/debian/control.xenomai-stretch.in
@@ -4,8 +4,8 @@ Architecture: any
 Provides:  machinekit-hal
 Conflicts: machinekit
 Depends: ${misc:Depends},
-    xenomai-runtime, python-numpy, python-vte, python-xlib, python-configobj,
-    python-zmq, python-protobuf (>= 2.4.1), python-gst1.0,
+    xenomai-runtime, python-numpy, python-xlib, python-configobj,
+    python-zmq, python-protobuf (>= 2.4.1),
     python-avahi, bc, procps, psmisc, module-init-tools | kmod,
     libzmq3-dev (>= 4.0.4), libczmq-dev (>= 4.0.2), libjansson4, yapps2-runtime, cgroup-tools, uuid-runtime
 Description: HAL stack split from machinekit

--- a/debian/control.xenomai.in
+++ b/debian/control.xenomai.in
@@ -4,8 +4,8 @@ Architecture: any
 Provides:  machinekit-hal
 Conflicts: machinekit
 Depends: ${misc:Depends},
-    xenomai-runtime, python-numpy, python-vte, python-xlib, python-configobj,
-    python-zmq, python-protobuf (>= 2.4.1), python-gst0.10,
+    xenomai-runtime, python-numpy, python-xlib, python-configobj,
+    python-zmq, python-protobuf (>= 2.4.1), 
     python-avahi, bc, procps, psmisc, module-init-tools | kmod,
     libzmq3-dev (>= 4.0.4), libczmq-dev (>= 4.0.2), libjansson4, yapps2-runtime, cgroup-tools, uuid-runtime
 Description: HAL stack split from machinekit


### PR DESCRIPTION
These 2 are now deprecated from sid despite online docs references suggesting availability.

python-vte is a virtual terminal widget used in the gtk+2 toolkit
 and only really used for GUIs and one little used widget in gladevcp

python-gst0.1 / 1.0 was only required by gmoccapy to make pretty sounds
 and that had to be removed in Stretch and above because the relevant
 module was deprecated in the new library.

Signed-off-by: Mick <arceye@mgware.co.uk>