### PR TITLE
Change shebang for postinst to stop sh warnings over [[ ]] bracketing

### DIFF
--- a/debian/postinst.in
+++ b/debian/postinst.in
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash
 # postinst script for machinekit-hal
 
 touch /var/log/linuxcnc.log


### PR DESCRIPTION
Signed-off-by: Mick <arceye@mgware.co.uk>