### PR TITLE
scripts/runtests:  `-s` stops tests after first failure

### DIFF
--- a/scripts/runtests
+++ b/scripts/runtests
@@ -168,6 +168,9 @@ run_tests () {
 	$testdir"
 		echo "*** $testdir: FAIL: $reason"
 	    fi
+            if test $STOP = 1; then
+	        break
+	    fi
 	else
 	    if [ -f $testdir/xfail ]; then
 		echo "*** $testdir: XPASS: Passed, but was expected to fail"
@@ -196,9 +199,9 @@ usage () {
 $P: Run HAL test suite items
 
 Usage:
-    $P [-n] tests
+    $P [-n] [-s] tests
 	Run tests.  With '-n', do not remove temporary files for successful
-	tests.
+	tests.  With '-s', stop after any failed test.
 
     $P -c tests
 	Remove temporary files from an earlier test run.
@@ -220,11 +223,13 @@ trap "rm -rf $TMPDIR" 0 1 2 3 9 15
 
 CLEAN_ONLY=0
 NOCLEAN=0
-while getopts cnvh opt; do
+STOP=0
+while getopts cnvsh opt; do
     case "$opt" in
     c) CLEAN_ONLY=1 ;;
     n) NOCLEAN=1 ;;
     v) VERBOSE=1 ;;
+    s) STOP=1 ;;
     h|?) usage; exit 0 ;;
     *) usage; exit 1 ;;
     esac


### PR DESCRIPTION
When you know lots of things are broken, `runtests -s` will run until the first test failure and not spew.