### PR TITLE
Add script to enable full RIP builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@ It can be built as a RIP and used in the same way as a machinekit RIP, but witho
 
 Install _machinekit-hal-{flavour}_  if using packages.
 
-PR's should not be made directly to this repo without prior notice.
-
-The machinekit repo is periodically cherry-picked for relevant new commits by the developers
-and machinekit-hal updated from these.
-
 NB. There is a related repo __machinekit-cnc__, which contains all the CNC elements missing from this repo.
+    This can be built as a combined RIP build with machinekit-hal, by invoking scripts/build_with_cnc
+    from the root of the machinekit-hal clone.
 

--- a/scripts/build_with_cnc
+++ b/scripts/build_with_cnc
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+MKHAL_DIR=$(pwd)
+
+cd src
+
+./autogen.sh
+
+./configure
+
+make -j $(nproc)
+
+sudo make setuid
+
+cd ../
+
+git clone https://github.com/machinekit/machinekit-cnc ;
+
+cd machinekit-cnc/src
+
+./autogen.sh
+
+./configure --with-machinekit-hal=$MKHAL_DIR
+
+make -j $(nproc)
+
+cd ../
+
+cp -f bin/* $MKHAL_DIR/bin ;
+cp -f -R configs $MKHAL_DIR ;
+cp -f -L -R include/* $MKHAL_DIR/include ;
+cp -f -L -R lib/*  $MKHAL_DIR/lib ;
+cp -f -R nc_files $MKHAL_DIR ;
+cp -f -R rtlib/* $MKHAL_DIR/rtlib ;
+cp -f -R share/* $MKHAL_DIR/share ;
+sed -i 's|\/machinekit-cnc||g' tcl/linuxcnc.tcl ;
+cp -f -R tcl/* $MKHAL_DIR/tcl ;
+cp -f -R www $MKHAL_DIR ;
+
+cp -f machinekit* $MKHAL_DIR ;
+
+mkdir -p scripts/stash ;
+mv scripts/build_docker scripts/stash ;
+mv scripts/build_source_package scripts/stash ;
+sed -i 's|\/machinekit-cnc||g' scripts/linuxcnc ;
+cp -f scripts/* $MKHAL_DIR/scripts > /dev/null 2>&1 ;
+
+cd ../
+
+. ./scripts/rip-environment 
+
+echo "********************************"
+echo "Ready to run full machinekit RIP"
+echo "********************************"


### PR DESCRIPTION
Since machinekit-cnc is not able to be built without libs and
headers from machinekit-hal, pull a clone of machinekit-cnc
into root of machinekit-hal, build it and copy built libs and
binaries etc into machinekit-hal.

`machinekit` can then be invoked in same way as a RIP build
of the old machinekit repo

Signed-off-by: Mick <arceye@mgware.co.uk>