### PR TITLE
Add conflicts to prevent multi-flavour installation

### DIFF
--- a/debian/control.d/control.posix.hdr
+++ b/debian/control.d/control.posix.hdr
@@ -2,5 +2,5 @@
 Package: machinekit-hal-posix
 Architecture: any
 Provides:  machinekit-hal
-Conflicts: machinekit
+Conflicts: machinekit, machinekit-hal-rt-preempt, machinekit-hal-xenomai
 Suggests: hostmot2-firmware-all [!armhf]

--- a/debian/control.d/control.rt-preempt.hdr
+++ b/debian/control.d/control.rt-preempt.hdr
@@ -2,5 +2,5 @@
 Package: machinekit-hal-rt-preempt
 Architecture: any
 Provides:  machinekit-hal
-Conflicts: machinekit
+Conflicts: machinekit, machinekit-hal-posix, machinekit-hal-xenomai
 Suggests: hostmot2-firmware-all [!armhf]

--- a/debian/control.d/control.xenomai.hdr
+++ b/debian/control.d/control.xenomai.hdr
@@ -2,5 +2,5 @@
 Package: machinekit-hal-xenomai
 Architecture: any
 Provides:  machinekit-hal
-Conflicts: machinekit
+Conflicts: machinekit, machinekit-hal-posix, machinekit-hal-rt-preempt
 Suggests: hostmot2-firmware-all [!armhf]


### PR DESCRIPTION
Can be removed after https://github.com/machinekit/machinekit/pull/1462 is finished and implemented here.

That will allow a single package install for all flavours with only minor flavour dependent items in separate packages (if at all).

Fixes remainder of #201