### PR TITLE
Add back haltcl script.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -429,6 +429,7 @@ INFILES = \
 	Makefile.inc \
 	Makefile.modinc \
 	../scripts/halrun \
+	../scripts/haltcl \
 	../scripts/rip-environment
 
 $(INFILES): %: %.in config.status
@@ -746,7 +747,7 @@ endif
 install-kernel-indep: install-dirs
 	$(EXE) ../scripts/realtime $(DESTDIR)$(bindir)
 	$(EXE) ../scripts/halrun $(DESTDIR)$(bindir)
-
+	$(EXE) ../scripts/haltcl $(DESTDIR)$(bindir)
 	$(EXE) $(filter ../bin/%,$(TARGETS)) $(DESTDIR)$(bindir)
 	$(FILE) $(filter ../lib/%.a ../lib/%.so.0,$(TARGETS)) $(DESTDIR)$(libdir)
 	cp --no-dereference $(filter ../lib/%.so, $(TARGETS)) $(DESTDIR)$(libdir)

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3135,7 +3135,7 @@ AC_CONFIG_FILES([../scripts/check-build-vs-configure-sha], [chmod +x ../scripts/
 #AC_CONFIG_FILES([../scripts/linuxcnc], [chmod +x ../scripts/linuxcnc])
 AC_CONFIG_FILES([../scripts/halrun], [chmod +x ../scripts/halrun])
 AC_CONFIG_FILES([../scripts/rip-environment], [chmod +x ../scripts/rip-environment])
-#AC_CONFIG_FILES([../scripts/haltcl], [chmod +x ../scripts/haltcl])
+AC_CONFIG_FILES([../scripts/haltcl], [chmod +x ../scripts/haltcl])
 AC_CONFIG_FILES([../scripts/realtime], [chmod +x ../scripts/realtime])
 #AC_CONFIG_FILES([../scripts/linuxcnc_var], [chmod +x ../scripts/linuxcnc_var])
 AC_CONFIG_FILES(Makefile.inc)

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -2233,8 +2233,8 @@ if test "xyes" = "x$RUN_IN_PLACE"; then
     EMC2_ICON=$EMC2_HOME/machinekiticon.png
     EMC2_BIN_DIR=$EMC2_HOME/bin
     EMC2_LIBEXEC_DIR=$EMC2_HOME/libexec
-#    EMC2_TCL_DIR=$EMC2_HOME/tcl
-#    EMC2_TCL_LIB_DIR=$EMC2_HOME/tcl
+    EMC2_TCL_DIR=$EMC2_HOME/tcl
+    EMC2_TCL_LIB_DIR=$EMC2_HOME/tcl
     EMC2_LANG_DIR=$EMC2_HOME/src/objects
     EMC2_PO_DIR=$EMC2_HOME/share/locale
     EMC2_HELP_DIR=$EMC2_HOME/help
@@ -2251,8 +2251,8 @@ else
     EMC2_SCRIPT=$EMC2_BIN_DIR/emc
     EMC2_SUFFIX=""
     EMC2_ICON=machinekiticon
-#    EMC2_TCL_DIR=${prefix}/lib/tcltk/linuxcnc
-#    EMC2_TCL_LIB_DIR=${prefix}/lib/tcltk/linuxcnc
+    EMC2_TCL_DIR=${prefix}/lib/tcltk/linuxcnc
+    EMC2_TCL_LIB_DIR=${prefix}/lib/tcltk/linuxcnc
     EMC2_LANG_DIR=${prefix}/share/linuxcnc/tcl/msgs
     EMC2_PO_DIR=${prefix}/share/locale
     EMC2_HELP_DIR=${prefix}/share/doc/linuxcnc
@@ -2284,8 +2284,8 @@ AC_DEFINE_UNQUOTED([GIT_CONFIG_SHA], "$GIT_CONFIG_SHA", [SHA valid when configur
 AC_SUBST([EMC2_SYSTEM_CONFIG_DIR])
 AC_SUBST([EMC2_BIN_DIR])
 AC_SUBST([EMC2_LIBEXEC_DIR])
-#AC_SUBST([EMC2_TCL_DIR])
-#AC_SUBST([EMC2_TCL_LIB_DIR])
+AC_SUBST([EMC2_TCL_DIR])
+AC_SUBST([EMC2_TCL_LIB_DIR])
 AC_SUBST([EMC2_HELP_DIR])
 AC_SUBST([EMC2_RTLIB_DIR])
 AC_SUBST([EMC2_LANG_DIR])


### PR DESCRIPTION
Was going to be implemented in -cnc repo, but now that hal.so
is built in -hal, makes sense to have it here as well.

Signed-off-by: Mick <arceye@mgware.co.uk>