### PR TITLE
Fix for ld: cannot find -ltclstub

### DIFF
--- a/src/hal/utils/Submakefile
+++ b/src/hal/utils/Submakefile
@@ -16,7 +16,7 @@ $(call TOOBJSDEPS, hal/utils/halsh.c) : EXTRAFLAGS += $(TCL_CFLAGS)
 	../lib/libmtalk.so.0 \
 	../lib/librtapi_math.so.0
 	$(ECHO) Linking $(notdir $@)
-	$(Q)$(CC) $(LDFLAGS) -shared $^  $(TCL_LIBS) -o $@ -ltclstub
+	$(Q)$(CC) $(LDFLAGS) -shared $^  $(TCL_LIBS) -o $@
 TARGETS += ../tcl/hal.so
 
 $(call TOOBJSDEPS, $(HALCMDCCSRCS)) : EXTRAFLAGS =  \


### PR DESCRIPTION
Fixes the following linking issue:
gcc -Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -Wl,-rpath-link,../lib -Wl,--no-as-needed -I. -Imachinetalk/build -Imachinetalk/nanopb -Imachinetalk/include -Ilibnml/linklist -Ilibnml/cms -Ilibnml/rcs -Ilibnml/inifile -Ilibnml/os_intf -Ilibnml/nml -Ilibnml/buffer -Ilibnml/posemath -Irtapi -Irtapi_export -Ihal/lib -I../include/machinetalk/protobuf -Ihal/vtable-example -Ihal/userfunct-example -Ihal/drivers -Ihal/cython -Ihal/accessor -Iemc/nml_intf -Iemc/kinematics -Iemc/motion -Iemc/tp -Iemc/ini -Iemc/rs274ngc -Iemc/pythonplugin -I/usr/include/python2.7 -fwrapv  -fno-strict-overflow -g -Wall -funwind-tables   -DULAPI -std=gnu99 -fgnu89-inline -fPIC  -shared objects/hal/utils/halcmd.o objects/hal/utils/halcmd_commands.o objects/hal/utils/halsh.o objects/hal/utils/halcmd_rtapiapp.o ../lib/liblinuxcncini.so.0 ../lib/liblinuxcnchal.so.0 ../lib/libmachinetalk-pb2++.so.0 ../lib/libmtalk.so.0 ../lib/librtapi_math.so.0  -o ../tcl/hal.so -L/usr/lib64 -ltclstub8.6 -lX11 -lXft -lfreetype -lfontconfig -lpthread -ldl -lz -lpthread -lm -L/usr/lib64 -ltk8.6 -lGL  -lXinerama  -o ../tcl/hal.so -ltclstub
/usr/bin/ld: cannot find -ltclstub
collect2: error: ld returned 1 exit status

Tclstub library name shouldn't be hard coded here as it will come from the src/Makefile.inc.in through $(TCL_LIBS) (e.g. in Fedora 30 it's name is: -ltclstub8.6).

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>