### PR TITLE
Fix hm2 spi

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1078,6 +1078,7 @@ hostmot2-objs +=			  \
     hal/drivers/mesa-hostmot2/sserial.o   \
     hal/drivers/mesa-hostmot2/stepgen.o   \
     hal/drivers/mesa-hostmot2/bspi.o  \
+    hal/drivers/mesa-hostmot2/dbspi.o  \
     hal/drivers/mesa-hostmot2/uart.o  \
     hal/drivers/mesa-hostmot2/pktuart.o  \
     hal/drivers/mesa-hostmot2/watchdog.o  \

--- a/src/hal/drivers/mesa-hostmot2/bspi.c
+++ b/src/hal/drivers/mesa-hostmot2/bspi.c
@@ -200,7 +200,7 @@ int hm2_bspi_write_chan(char* name, int chan, u32 val)
 
 EXPORT_SYMBOL_GPL(hm2_bspi_setup_chan);
 int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, float mhz,
-                        int delay, int cpol, int cpha, int noclear, int noecho)
+                        int delay, int cpol, int cpha, int noclear, int noecho, int samplelate)
 {
     hostmot2_t *hm2;
     u32 buff;
@@ -240,6 +240,7 @@ int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, float mhz,
 
     buff = (noecho != 0) << 31
         |  (noclear != 0) << 30
+        |  (samplelate != 0) << 29
         | ((delay <= 0)? 0x10 : (u32)((delay*board_mhz/1000.0)-1) & 0x1f) << 24
         | (cs & 0xF) << 16
         | (((u16)(board_mhz / (mhz * 2) - 1) & 0xFF)) << 8

--- a/src/hal/drivers/mesa-hostmot2/bspi.c
+++ b/src/hal/drivers/mesa-hostmot2/bspi.c
@@ -200,7 +200,7 @@ int hm2_bspi_write_chan(char* name, int chan, u32 val)
 
 EXPORT_SYMBOL_GPL(hm2_bspi_setup_chan);
 int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, float mhz,
-                        int delay, int cpol, int cpha, int clear, int echo)
+                        int delay, int cpol, int cpha, int noclear, int noecho)
 {
     hostmot2_t *hm2;
     u32 buff;
@@ -238,8 +238,8 @@ int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, float mhz,
         mhz=board_mhz/2;
     }
 
-    buff = (echo != 0) << 31
-        |  (clear != 0) << 30
+    buff = (noecho != 0) << 31
+        |  (noclear != 0) << 30
         | ((delay <= 0)? 0x10 : (u32)((delay*board_mhz/1000.0)-1) & 0x1f) << 24
         | (cs & 0xF) << 16
         | (((u16)(board_mhz / (mhz * 2) - 1) & 0xFF)) << 8

--- a/src/hal/drivers/mesa-hostmot2/dbspi.c
+++ b/src/hal/drivers/mesa-hostmot2/dbspi.c
@@ -1,0 +1,368 @@
+//
+//    Copyright (C) 2011 Andy Pugh
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+#include "config_module.h"
+#include RTAPI_INC_SLAB_H
+#include "rtapi.h"
+#include "rtapi_app.h"
+#include "rtapi_string.h"
+#include "rtapi_math.h"
+#include "hal.h"
+#include "hostmot2.h"
+
+int hm2_dbspi_parse_md(hostmot2_t *hm2, int md_index)
+{
+    // All this function actually does is allocate memory
+    // and give the dbspi modules names.
+
+
+    //
+    // some standard sanity checks
+    //
+
+    int i, j, r = -EINVAL;
+    hm2_module_descriptor_t *md = &hm2->md[md_index];
+
+    if (!hm2_md_is_consistent_or_complain(hm2, md_index, 0, 3, 0x40, 0x0007)) {
+        HM2_ERR("inconsistent Module Descriptor!\n");
+        return -EINVAL;
+    }
+
+    if (hm2->dbspi.num_instances != 0) {
+        HM2_ERR(
+                "found duplicate Module Descriptor for %s (inconsistent "
+                "firmware), not loading driver\n",
+                hm2_get_general_function_name(md->gtag)
+                );
+        return -EINVAL;
+    }
+
+    if (hm2->config.num_dbspis > md->instances) {
+        HM2_ERR(
+                "config defines %d dbspis, but only %d are available, "
+                "not loading driver\n",
+                hm2->config.num_dbspis,
+                md->instances
+                );
+        return -EINVAL;
+    }
+
+    if (hm2->config.num_dbspis == 0) {
+        return 0;
+    }
+
+    //
+    // looks good, start initializing
+    //
+
+    if (hm2->config.num_dbspis == -1) {
+        hm2->dbspi.num_instances = md->instances;
+    } else {
+        hm2->dbspi.num_instances = hm2->config.num_dbspis;
+    }
+
+    hm2->dbspi.instance = (hm2_dbspi_instance_t *)hal_malloc(hm2->dbspi.num_instances
+                                                     * sizeof(hm2_dbspi_instance_t));
+    if (hm2->dbspi.instance == NULL) {
+        HM2_ERR("out of memory!\n");
+        r = -ENOMEM;
+        goto fail0;
+    }
+
+    for (i = 0 ; i < hm2->dbspi.num_instances ; i++){
+        hm2_dbspi_instance_t *chan = &hm2->dbspi.instance[i];
+        chan->clock_freq = md->clock_freq;
+        r = rtapi_snprintf(chan->name, sizeof(chan->name), "%s.dbspi.%01d", hm2->llio->name, i);
+        HM2_PRINT("created Buffered SPI function %s.\n", chan->name);
+        chan->base_address = md->base_address + i * md->instance_stride;
+        chan->register_stride = md->register_stride;
+        chan->instance_stride = md->instance_stride;
+        chan->cd_addr = md->base_address + md->register_stride + i * sizeof(u32);
+        chan->count_addr = md->base_address + 2 * md->register_stride + i * sizeof(u32);
+        for (j = 0 ; j < 16 ; j++ ){
+            chan->addr[j] = chan->base_address + j * sizeof(u32);
+        }
+
+    }
+    return hm2->dbspi.num_instances;
+fail0:
+    return r;
+}
+
+void hm2_dbspi_force_write(hostmot2_t *hm2)
+{
+    int i, j;
+    for (i = 0 ; i < hm2->dbspi.num_instances ; i++){
+        hm2_dbspi_instance_t chan = hm2->dbspi.instance[i];
+        // write the channel descriptors
+        for (j = 15 ; j >=0 ; j--){
+            hm2->llio->write(hm2->llio, chan.cd_addr, &(chan.cd[j]), sizeof(u32));
+        }
+    }
+}
+
+EXPORT_SYMBOL_GPL(hm2_tram_add_dbspi_frame);
+int hm2_tram_add_dbspi_frame(char *name, int chan, u32 **wbuff, u32 **rbuff)
+{
+    hostmot2_t *hm2;
+    int i, r;
+    i = hm2_get_dbspi(&hm2, name);
+    if (i < 0){
+        HM2_ERR_NO_LL("Can not find DBSPI instance %s.\n", name);
+        return -1;
+    }
+    if (hm2->dbspi.instance[i].conf_flag[chan] != true){
+        HM2_ERR("The selected write channel (%i) on dbspi instance %s.\n"
+                "Has not been configured.\n", chan, name);
+        return -1;
+    }
+    if (wbuff != NULL) {
+        r = hm2_register_tram_write_region(hm2,hm2->dbspi.instance[i].addr[chan], sizeof(u32),wbuff);
+        if (r < 0) {
+            HM2_ERR("Failed to add TRAM write entry for %s.\n", name);
+            return -1;
+        }
+    } else {
+        HM2_ERR("SPI frame must have a write entry for channel (%i) on %s.\n", chan, name);
+        return -1;
+    }
+    if (rbuff != NULL){
+        // Don't add a read entry for a no-echo channel
+        if(!(hm2->dbspi.instance[i].cd[chan] & 0x80000000)) {
+            r = hm2_register_tram_read_region(hm2,hm2->dbspi.instance[i].addr[0], sizeof(u32),rbuff);
+            if (r < 0) {
+                HM2_ERR( "Failed to add TRAM read entry for %s\n", name);
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+EXPORT_SYMBOL_GPL(hm2_allocate_dbspi_tram);
+int hm2_allocate_dbspi_tram(char* name)
+{
+    hostmot2_t *hm2;
+    int i, r;
+    i = hm2_get_dbspi(&hm2, name);
+    if (i < 0){
+        HM2_ERR_NO_LL("Can not find DBSPI instance %s.\n", name);
+        return -1;
+    }
+    r = hm2_allocate_tram_regions(hm2);
+    if (r < 0) {
+        HM2_ERR("Failed to register TRAM for DBSPI %s\n", name);
+        return -1;
+    }
+
+    return 0;
+}
+
+EXPORT_SYMBOL_GPL(hm2_dbspi_write_chan);
+int hm2_dbspi_write_chan(char* name, int chan, u32 val)
+{
+    hostmot2_t *hm2;
+    u32 buff = val;
+    int i, r;
+    i = hm2_get_dbspi(&hm2, name);
+    if (i < 0){
+        HM2_ERR_NO_LL("Can not find DBSPI instance %s.\n", name);
+        return -1;
+    }
+    if (hm2->dbspi.instance[i].conf_flag[chan] != true){
+        HM2_ERR("The selected write channel (%i) on dbspi instance %s.\n"
+                "Has not been configured.\n", chan, name);
+        return -1;
+    }
+    r = hm2->llio->write(hm2->llio, hm2->dbspi.instance[i].addr[chan], &buff, sizeof(u32));
+    if (r < 0) {
+        HM2_ERR("DBSPI: hm2->llio->write failure %s\n", name);
+    }
+
+    return r;
+}
+
+EXPORT_SYMBOL_GPL(hm2_dbspi_setup_chan);
+int hm2_dbspi_setup_chan(char *name, int chan, int cs, int bits, float mhz,
+                        int delay, int cpol, int cpha, int noclear, int noecho, int samplelate)
+{
+    hostmot2_t *hm2;
+    u32 buff;
+    int i;
+    float board_mhz;
+    i = hm2_get_dbspi(&hm2, name);
+    if (i < 0){
+        HM2_ERR_NO_LL("Can not find DBSPI instance %s.\n", name);
+        return -1;
+    }
+    if (chan<0 || chan > 15){
+        HM2_ERR("DBSPI %s: Channel number (%i) is out of range, DBSPI only"
+                "supports channels 0-15\n", name, chan);
+        return -1;
+    }
+    if (cs > 15 || cs < 0){
+        HM2_ERR("DBSPI %s: Chip Select for channel %i (%i) out of range, only "
+                "values 0 - 15 are accepted\n", name, chan, cs);
+        return -1;
+    }
+    if (bits > 64 || bits < 1){
+        HM2_ERR("DBSPI %s: Number of bits for chan %i (%i) is out of range, "
+                "DBSPI only supports 1-64 bits\n", name, chan, bits);
+        return -1;
+    }
+    if (delay < 0 || delay > 1e6){
+        HM2_ERR("The requested frame delay on channel %i of %inS seems "
+                "rather implausible for an SPI device. Exiting.\n", delay, chan);
+        return -1;
+    }
+    board_mhz = hm2->dbspi.instance[i].clock_freq / 1e6;
+
+    // reduce clock rate of the FPGA isn't fast enough
+    if (mhz > board_mhz/2){
+        mhz=board_mhz/2;
+    }
+
+    buff = (noecho != 0) << 31
+        |  (noclear != 0) << 30
+        |  (samplelate != 0) << 29
+        | ((delay <= 0)? 0x10 : (u32)((delay*board_mhz/1000.0)-1) & 0x1f) << 24
+        | (cs & 0xF) << 16
+        | (((u16)(board_mhz / (mhz * 2) - 1) & 0xFF)) << 8
+        | (cpha != 0) << 7
+        | (cpol != 0) << 6
+        | (((u16)(bits - 1)) & 0x3F);
+    HM2_DBG("DBSPI %s Channel %i setup %x\n", name, chan, buff);
+    hm2->dbspi.instance[i].cd[chan] = buff;
+    hm2->dbspi.instance[i].conf_flag[chan] = true;
+    hm2_dbspi_force_write(hm2);
+    return 0;
+}
+
+void hm2_dbspi_print_module(hostmot2_t *hm2){
+    int i,j;
+    HM2_PRINT("Buffered SPI: %d\n", hm2->dbspi.num_instances);
+    if (hm2->dbspi.num_instances <= 0) return;
+    HM2_PRINT("    version: %d\n", hm2->dbspi.version);
+    HM2_PRINT("    channel configurations\n");
+    for (i = 0; i < hm2->dbspi.num_instances; i ++) {
+        HM2_PRINT("    clock_frequency: %d Hz (%s MHz)\n",
+                  hm2->dbspi.instance[i].clock_freq,
+                  hm2_hz_to_mhz(hm2->dbspi.instance[i].clock_freq));
+        HM2_PRINT("    instance %d:\n", i);
+        HM2_PRINT("    HAL name = %s\n", hm2->dbspi.instance[i].name);
+        for (j = 0; j < 16 ; j++){
+            HM2_PRINT("         frame %i config = %08x\n", j,
+                      hm2->dbspi.instance[i].cd[j]);
+            HM2_PRINT("                address = %08x\n",
+                      hm2->dbspi.instance[i].addr[j]);
+        }
+    }
+}
+
+EXPORT_SYMBOL_GPL(hm2_dbspi_set_read_function);
+int hm2_dbspi_set_read_function(char *name, int (*func)(void *subdata), void *subdata){
+    hostmot2_t *hm2;
+    int i;
+    i = hm2_get_dbspi(&hm2, name);
+    if (i < 0){
+        HM2_ERR_NO_LL("Can not find DBSPI instance %s.\n", name);
+        return -1;
+    }
+    if (func == NULL) {
+        HM2_ERR("Invalid function pointer passed to "
+                "hm2_dbspi_set_read_function.\n");
+        return -1;
+    }
+    if (subdata == NULL) {
+        HM2_ERR("Invalid data pointer passed to "
+                "hm2_dbspi_set_read_function.\n");
+        return -1;
+    }
+    hm2->dbspi.instance[i].read_function = func;
+    hm2->dbspi.instance[i].subdata = subdata;
+    return 0;
+}
+
+EXPORT_SYMBOL_GPL(hm2_dbspi_set_write_function);
+int hm2_dbspi_set_write_function(char *name, int (*func)(void *subdata), void *subdata){
+    hostmot2_t *hm2;
+    int i;
+    i = hm2_get_dbspi(&hm2, name);
+    if (i < 0){
+        HM2_ERR_NO_LL("Can not find DBSPI instance %s.\n", name);
+        return -1;
+    }
+    if (func == NULL) {
+        HM2_ERR("Invalid function pointer passed to "
+                "hm2_dbspi_set_write_function.\n");
+        return -1;
+    }
+    if (subdata == NULL) {
+        HM2_ERR("Invalid data pointer passed to "
+                "hm2_dbspi_set_write_function.\n");
+        return -1;
+    }
+    hm2->dbspi.instance[i].write_function = func;
+    hm2->dbspi.instance[i].subdata = subdata;
+    return 0;
+}
+
+
+void hm2_dbspi_process_tram_read(hostmot2_t *hm2, long period)
+{
+    int i, r;
+    int (*func)(void *subdata);
+    for (i = 0 ; i < hm2->dbspi.num_instances ; i++ ){
+        func = hm2->dbspi.instance[i].read_function;
+        if (func != NULL){
+            r = func(hm2->dbspi.instance[i].subdata);
+            if(r < 0)
+                HM2_ERR("DBSPI read function @%p failed (returned %d)\n",
+                        func, r);
+        }
+    }
+}
+
+void hm2_dbspi_prepare_tram_write(hostmot2_t *hm2, long period)
+{
+    int i, r;
+    int (*func)(void *subdata);
+    for (i = 0 ; i < hm2->dbspi.num_instances ; i++ ){
+        func = hm2->dbspi.instance[i].write_function;
+        if (func != NULL){
+            r = func(hm2->dbspi.instance[i].subdata);
+            if(r < 0)
+                HM2_ERR("DBSPI read function @%p failed (returned %d)\n",
+                        func, r);
+        }
+    }
+}
+
+// The following standard Hostmot2 functions are not currently used by dbspi.
+
+void hm2_dbspi_cleanup(hostmot2_t *hm2)
+{
+}
+
+void hm2_dbspi_write(hostmot2_t *hm2)
+{
+}
+
+
+

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -1436,7 +1436,7 @@ int hm2_bspi_write_chan(char* name, int chan, u32 val);
 int hm2_allocate_bspi_tram(char* name);
 int hm2_tram_add_bspi_frame(char *name, int chan, u32 **wbuff, u32 **rbuff);
 int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, float mhz,
-int delay, int cpol, int cpha, int clear, int echo);
+int delay, int cpol, int cpha, int noclear, int noecho);
 int hm2_bspi_set_read_function(char *name, int (*func)(void *subdata), void *subdata);
 int hm2_bspi_set_write_function(char *name, int (*func)(void *subdata), void *subdata);
 

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -1436,7 +1436,7 @@ int hm2_bspi_write_chan(char* name, int chan, u32 val);
 int hm2_allocate_bspi_tram(char* name);
 int hm2_tram_add_bspi_frame(char *name, int chan, u32 **wbuff, u32 **rbuff);
 int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, float mhz,
-int delay, int cpol, int cpha, int noclear, int noecho);
+int delay, int cpol, int cpha, int noclear, int noecho, int samplelate);
 int hm2_bspi_set_read_function(char *name, int (*func)(void *subdata), void *subdata);
 int hm2_bspi_set_write_function(char *name, int (*func)(void *subdata), void *subdata);
 

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -172,7 +172,7 @@ char **argv_split(gfp_t gfp, const char *str, int *argcp);
 #define HM2_GTAG_MUXED_ENCODER     (12)
 #define HM2_GTAG_MUXED_ENCODER_SEL (13)
 #define HM2_GTAG_BSPI              (14)
-#define HM2_GTAG_DBSPI             (15) // Not supported
+#define HM2_GTAG_DBSPI             (15)
 #define HM2_GTAG_DPLL              (16) // Not supported
 #define HM2_GTAG_MUXED_ENCODER_M   (17) // Not supported
 #define HM2_GTAG_MUXED_ENC_SEL_M   (18) // Not supported
@@ -855,6 +855,36 @@ typedef struct {
 } hm2_bspi_t;
 
 //
+// Buffered SPI with decoded cs transciever
+//
+
+typedef struct {
+    u32 cd[16];
+    u16 addr[16];
+    int conf_flag[16];
+    u16 cd_addr;
+    u16 count_addr;
+    hal_u32_t *count;
+    int num_frames;
+    u32 clock_freq;
+    u16 base_address;
+    u32 register_stride;
+    u32 instance_stride;
+    char name[HAL_NAME_LEN+1];
+    void *read_function;
+    void *write_function;
+    void *subdata;
+} hm2_dbspi_instance_t;
+
+typedef struct {
+    int version;
+    int num_instances;
+    hm2_dbspi_instance_t *instance;
+    u8 instances;
+    u8 num_registers;
+} hm2_dbspi_t;
+
+//
 // UART
 //
 
@@ -1161,6 +1191,7 @@ typedef struct {
         int num_leds;
         int num_sserials;
         int num_bspis;
+        int num_dbspis;
         int num_uarts;
         int num_pktuarts;
         int num_dplls;
@@ -1208,6 +1239,7 @@ typedef struct {
     hm2_stepgen_t stepgen;
     hm2_sserial_t sserial;
     hm2_bspi_t bspi;
+    hm2_dbspi_t dbspi;
     hm2_uart_t uart;
     hm2_pktuart_t pktuart;
     hm2_ioport_t ioport;
@@ -1261,6 +1293,7 @@ void hm2_print_modules(hostmot2_t *hm2);
 // functions to get handles to components by name
 hm2_sserial_remote_t *hm2_get_sserial(hostmot2_t **hm2, char *name);
 int hm2_get_bspi(hostmot2_t **hm2, char *name);
+int hm2_get_dbspi(hostmot2_t **hm2, char *name);
 int hm2_get_uart(hostmot2_t **hm2, char *name);
 int hm2_get_pktuart(hostmot2_t **hm2, char *name);
 
@@ -1439,6 +1472,26 @@ int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, float mhz,
 int delay, int cpol, int cpha, int noclear, int noecho, int samplelate);
 int hm2_bspi_set_read_function(char *name, int (*func)(void *subdata), void *subdata);
 int hm2_bspi_set_write_function(char *name, int (*func)(void *subdata), void *subdata);
+
+//
+// Buffered SPI with cs decoder functions
+//
+
+int  hm2_dbspi_parse_md(hostmot2_t *hm2, int md_index);
+void hm2_dbspi_print_module(hostmot2_t *hm2);
+void hm2_dbspi_cleanup(hostmot2_t *hm2);
+void hm2_dbspi_write(hostmot2_t *hm2);
+void hm2_dbspi_force_write(hostmot2_t *hm2);
+void hm2_dbspi_prepare_tram_write(hostmot2_t *hm2, long period);
+void hm2_dbspi_process_tram_read(hostmot2_t *hm2, long period);
+int hm2_allocate_dbspi_tram(char* name);
+int hm2_dbspi_write_chan(char* name, int chan, u32 val);
+int hm2_allocate_dbspi_tram(char* name);
+int hm2_tram_add_dbspi_frame(char *name, int chan, u32 **wbuff, u32 **rbuff);
+int hm2_dbspi_setup_chan(char *name, int chan, int cs, int bits, float mhz,
+int delay, int cpol, int cpha, int noclear, int noecho, int samplelate);
+int hm2_dbspi_set_read_function(char *name, int (*func)(void *subdata), void *subdata);
+int hm2_dbspi_set_write_function(char *name, int (*func)(void *subdata), void *subdata);
 
 //
 // UART functions

--- a/src/hal/drivers/mesa_7i65.comp
+++ b/src/hal/drivers/mesa_7i65.comp
@@ -163,27 +163,27 @@ EXTRA_SETUP(){
 
     firstrun = true;
     // Set up channel descriptors
-    //hm2_bspi_setup_chan(name, chan, cs, bits, mhz, delay(ns), cpol, cpha, /clear, /echo)
+    //hm2_bspi_setup_chan(name, chan, cs, bits, mhz, delay(ns), cpol, cpha, noclear, noecho, samplelate)
     // CS0 loopback Echo, CS0, ~ 4 MHz, CPOL, 32 bits
-    r = hm2_bspi_setup_chan(name, 0, 0, 32, 4, 0, 1, 0, 0, 0);
+    r = hm2_bspi_setup_chan(name, 0, 0, 32, 4, 0, 1, 0, 0, 0, 0);
     // CS1 AD5754 No echo, CS1, 25 MHz, CPOL, 24 bits
-    r += hm2_bspi_setup_chan(name, 1, 1, 24, 25, 0, 1, 0, 0, 1);
+    r += hm2_bspi_setup_chan(name, 1, 1, 24, 25, 0, 1, 0, 0, 1, 0);
     // CS2 AD5754 No echo, CS2, 25 MHz, CPOL, 24 bits
-    r += hm2_bspi_setup_chan(name, 2, 2, 24, 25, 0, 1, 0, 0, 1);
+    r += hm2_bspi_setup_chan(name, 2, 2, 24, 25, 0, 1, 0, 0, 1, 0);
     // CS3 AD7329 Echo, CS3, ~6 MHz, CPOL, 16 bits
-    r += hm2_bspi_setup_chan(name, 3, 3, 16, 6, 0, 1, 0, 0, 0);
+    r += hm2_bspi_setup_chan(name, 3, 3, 16, 6, 0, 1, 0, 0, 0, 0);
     // CS4 CPLD Echo, CS4, ~6 MHz, CPOL, 12 bits
-    r += hm2_bspi_setup_chan(name, 4, 4, 12, 6, 0, 1, 0, 0, 0);
+    r += hm2_bspi_setup_chan(name, 4, 4, 12, 6, 0, 1, 0, 0, 0, 0);
     // CS5 Not Used No echo, CS5, 25 MHz, 2 bits
-    r += hm2_bspi_setup_chan(name, 5, 5, 2, 25, 0, 1, 0, 0, 1);
+    r += hm2_bspi_setup_chan(name, 5, 5, 2, 25, 0, 1, 0, 0, 1, 0);
     // CS6 Not Used No echo, CS5, 25 MHz, 2 bits
-    r += hm2_bspi_setup_chan(name, 6, 6, 2, 25, 0, 1, 0, 0, 1);
+    r += hm2_bspi_setup_chan(name, 6, 6, 2, 25, 0, 1, 0, 0, 1, 0);
     // CS7 EEPROM Echo, CS7, ~4 MHz, CPOL,CPHA, 8 bits
-    r += hm2_bspi_setup_chan(name, 7, 7, 8, 4, 0, 1, 1, 0, 0);
+    r += hm2_bspi_setup_chan(name, 7, 7, 8, 4, 0, 1, 1, 0, 0, 0);
     // CS7 EEPROM No Echo, CS7, ~4 MHz, CPOL,CPHA, 8 bits
-    r += hm2_bspi_setup_chan(name, 8, 7, 8, 4, 0, 1, 1, 0, 1);
+    r += hm2_bspi_setup_chan(name, 8, 7, 8, 4, 0, 1, 1, 0, 1, 0);
     // CS7 EEPROM No Echo, DontClearFrame, CS7, ~4 MHz,CPOL,CPHA, 8 bits
-    r += hm2_bspi_setup_chan(name, 9, 7, 8, 4, 0, 1, 1, 1, 1);
+    r += hm2_bspi_setup_chan(name, 9, 7, 8, 4, 0, 1, 1, 1, 1, 0);
 
     if (r < 0) {
         HM2_ERR_NO_LL("There have been %i errors during channel setup, "


### PR DESCRIPTION
I found 2 bugs trying to implement spi functionality on the mksocfpga.
Then looked at the bspi.c file history in Linuxcnc:
https://github.com/LinuxCNC/linuxcnc/commits/master/src/hal/drivers/mesa-hostmot2/bspi.c
And found the same fixes and some additional enhancements I added also.
Lastly I added support for the dbspi (buffered spi's with decoded chip selects), as a separete file.
Tested to work on Mksocfpga.