### PR TITLE
 rtapi/rt-preempt: Raise cpu affinity and cgroup messages from debug to info

### DIFF
--- a/src/rtapi/rt-preempt.c
+++ b/src/rtapi/rt-preempt.c
@@ -283,7 +283,7 @@ static int realtime_set_affinity(task_data *task) {
 			task_id(task), task->name, use_cpu, strerror(errno));
 	return -EINVAL;
     }
-    rtapi_print_msg(RTAPI_MSG_DBG,
+    rtapi_print_msg(RTAPI_MSG_INFO,
 		    "realtime_set_affinity(): task %s assigned to CPU %d\n", 
 		    task->name, use_cpu);
     return 0;
@@ -350,7 +350,7 @@ static void *realtime_thread(void *arg) {
                             task->name, task->cgname, cgroup_strerror(ret));
             goto error;
         }
-        rtapi_print_msg(RTAPI_MSG_DBG,
+        rtapi_print_msg(RTAPI_MSG_INFO,
                         "Moved task '%s' to cpuset '%s'",
                         task->name, task->cgname);
     }


### PR DESCRIPTION
It is important to know the CPU affinity settings. That info should be available under INFO message level.