### PR TITLE
Add libatomic to RTAPI_MSGD_LDFLAGS

### DIFF
--- a/src/rtapi/Submakefile
+++ b/src/rtapi/Submakefile
@@ -364,7 +364,7 @@ RTAPI_MSGD_CFLAGS := \
 
 RTAPI_MSGD_LDFLAGS := \
 	$(PROTOBUF_LIBS) $(CZMQ_LIBS) $(AVAHI_LIBS) \
-	-lstdc++ -ldl -luuid
+	-lstdc++ -ldl -luuid -latomic -lrt -lzmq
 
 #	$(LIBBACKTRACE) # already linked into libmtalk
 
@@ -378,7 +378,7 @@ $(call TOOBJSDEPS, $(RTAPI_MSGD_SRCS)): \
 	../lib/libmachinetalk-pb2++.so 
 	$(ECHO) Linking $(notdir $@)
 	@mkdir -p $(dir $@)
-	$(Q)$(CC)  $(LDFLAGS) -o $@ $^ $(RTAPI_MSGD_LDFLAGS) -lrt -lzmq
+	$(Q)$(CC)  $(LDFLAGS) -o $@ $^ $(RTAPI_MSGD_LDFLAGS)
 
 USERSRCS += $(RTAPI_MSGD_SRCS)
 TARGETS += ../libexec/rtapi_msgd


### PR DESCRIPTION
This to prevent a reported DSO error when building on Raspian
whereby __atomic_fetch() etc used by rtapi functions are
not resolved by newer linkers

Also moved -lrt and -lzmq there for uniformity.

Signed-off-by: Mick <arceye@mgware.co.uk>