### PR TITLE
realtime script:  Fix RTAPI unload detection in Jessie

### DIFF
--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -155,7 +155,7 @@ FindRunningProcs() {
     if test -z "$all"; then
 	return  # No procs named $proc_name found at all
     fi
-    local live="$(ps -p "$all" -o pid=,s= | ${AWK} '$2 != "Z" {print $1}')"
+    local live="$(ps -p "$all" -o pid= -o s= | ${AWK} '$2 != "Z" {print $1}')"
     if test -z "$live"; then
 	return  # No non-zombie procs named $proc_name found
     fi


### PR DESCRIPTION
In Stretch and Buster, output formats may be combined with commas:

    $ ps -p 1 -o pid=,s=
        1 S

On Jessie, this does not work:

    $ ps -p 1 -o pid=,s=
      ,s=
        1

But separating them as separate options does:

    $ ps -p 1 -o pid= -o s=
        1 S

This patch fixes e.g. `rtapi:0` exit detection in the `realtime`
script, a problem introduced by YT in 61446ef4.

Fixes #164.