### PR TITLE
rtapi: make syslog logging less verbose without debug flag

### DIFF
--- a/src/rtapi/rtapi_app.cc
+++ b/src/rtapi/rtapi_app.cc
@@ -1711,7 +1711,12 @@ int main(int argc, char **argv)
     }
 
     openlog_async(argv[0], option, LOG_LOCAL1);
-    setlogmask_async(LOG_UPTO(LOG_DEBUG));
+    if (debug) {
+        setlogmask_async(LOG_UPTO(LOG_DEBUG));
+    }
+    else {
+        setlogmask_async(LOG_UPTO(LOG_ERR));
+    }
     // max out async syslog buffers for slow system in debug mode
     tunelog_async(99,10);
 

--- a/src/rtapi/rtapi_msgd.cc
+++ b/src/rtapi/rtapi_msgd.cc
@@ -117,6 +117,7 @@ long page_size;
 static int usr_msglevel = RTAPI_MSG_INFO ;
 static int rt_msglevel = RTAPI_MSG_INFO ;
 static int halsize;
+static int debug;
 static int hal_thread_stack_size = HAL_STACKSIZE;
 static size_t message_ring_size = MESSAGE_RING_SIZE;
 static int hal_descriptor_alignment = 0;
@@ -831,6 +832,9 @@ int main(int argc, char **argv)
 	case 'r':
 	    rt_msglevel = atoi(optarg);
 	    break;
+	case 'd':
+	    debug++;
+	    break;
 	case 'H':
 	    halsize = atoi(optarg);
 	    break;
@@ -969,6 +973,12 @@ int main(int argc, char **argv)
     backtrace_init(proctitle);
 
     openlog_async(proctitle, option , SYSLOG_FACILITY);
+    if (debug) {
+        setlogmask_async(LOG_UPTO(LOG_DEBUG));
+    }
+    else {
+        setlogmask_async(LOG_UPTO(LOG_ERR));
+    }
     // max out async syslog buffers for slow system in debug mode
     tunelog_async(99,10);
 


### PR DESCRIPTION
Syslog logging is unreasonably verbose when not debugging, which slows down some machines when starting a program.

This patch reduces the syslog log level to `LOG_ERR` when rtapi is not started with debug flags.