### PR TITLE
Allow testing for .deb package creation for Buster arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ env:
     # Packages
     # - Buster
     - TAG=amd64_10    CMD=deb
-    # - TAG=arm64_10    CMD=deb # Waiting for Buster libck-dev:arm64 packages
+    - TAG=arm64_10    CMD=deb
     - TAG=i386_10     CMD=deb
     - TAG=armhf_10    CMD=deb
     # - Stretch
@@ -75,9 +75,6 @@ env:
     - TAG=amd64_8    CMD=deb
     - TAG=i386_8     CMD=deb
     - TAG=armhf_8    CMD=deb
-matrix:
-  allow_failures:
-    - env:  TAG=arm64_10   CMD=deb
 
 addons:
   apt:


### PR DESCRIPTION
Allowing building Debian packages for arm64 on Buster.

The reason why this was forbidden is no longer valid:

1. The libck-dev for arm64 Buster was added to `deb.machinekit.io` repository long ago
2. The libck-dev for arm64 Buster can now be had from official `deb.debian.org` `Buster-backports` repository (where the slightly newer version resides)

However, one can just use standard DovetailAutomata/mk-cross-builder to build the mk-cross-builder:arm64_10 container image (this downloads the libck-dev from Machinekit repository) and all works without problems.

