### PR TITLE
Enable co-installation of machinekit-hal and machinekit-hal-dev packages

### DIFF
--- a/debian/machinekit-hal-dev.install
+++ b/debian/machinekit-hal-dev.install
@@ -1,4 +1,3 @@
-usr/bin/comp
 usr/include/linuxcnc
 usr/lib/lib*.so
 usr/share/linuxcnc/Makefile.*

--- a/debian/machinekit-hal.install
+++ b/debian/machinekit-hal.install
@@ -20,5 +20,7 @@ usr/lib/python*/*/machinekit/nosetests/*.py
 usr/lib/python*/dist-packages/gladevcp
 usr/lib/tcltk/linuxcnc/hal.so
 usr/libexec/linuxcnc
-usr/share/linuxcnc
+usr/share/linuxcnc/udev
+usr/share/linuxcnc/examples
+usr/share/linuxcnc/ncfiles
 usr/share/machinekit


### PR DESCRIPTION
This pull request fixes #271 by putting the `comp` executable into `machinekit-hal` package instead of in `machinekit-hal-dev` package.

By this you can install `machinekit-hal-dev` on top of `machinekit-hal` without errors.