### PR TITLE
Rework of buildsystem, part 1

### DIFF
--- a/scripts/build_docker
+++ b/scripts/build_docker
@@ -191,7 +191,7 @@ RUN echo '${USER}:*:17967:0:99999:7:::' >> /etc/shadow
 ENV UID=${UID_GID/:*/}
 EOF
 else
-    NEWTAG=${TAG}
+	NEWTAG=${TAG}
 fi
 
 ###########################################################

--- a/scripts/buildsystem/debian/multistrap-configs/bullseye.conf
+++ b/scripts/buildsystem/debian/multistrap-configs/bullseye.conf
@@ -20,7 +20,8 @@ packages=netcat-openbsd
 source=file:/tmp/debs ./
 
 [machinekit]
-source=http://deb.machinekit.io/debian
+source=https://dl.cloudsmith.io/public/machinekit/machinekit/deb/debian
+omitdebsrc=true
 suite=bullseye
 
 [debian]

--- a/scripts/buildsystem/debian/multistrap-configs/buster.conf
+++ b/scripts/buildsystem/debian/multistrap-configs/buster.conf
@@ -20,7 +20,8 @@ packages=netcat-openbsd
 source=file:/tmp/debs ./
 
 [machinekit]
-source=http://deb.machinekit.io/debian
+source=https://dl.cloudsmith.io/public/machinekit/machinekit/deb/debian
+omitdebsrc=true
 suite=buster
 
 [debian]

--- a/scripts/buildsystem/debian/multistrap-configs/jessie.conf
+++ b/scripts/buildsystem/debian/multistrap-configs/jessie.conf
@@ -19,7 +19,8 @@ packages=libxenomai-dev
 source=file:/tmp/debs ./
 
 [machinekit]
-source=http://deb.machinekit.io/debian
+source=https://dl.cloudsmith.io/public/machinekit/machinekit/deb/debian
+omitdebsrc=true
 suite=jessie
 
 [debian]

--- a/scripts/buildsystem/debian/multistrap-configs/stretch.conf
+++ b/scripts/buildsystem/debian/multistrap-configs/stretch.conf
@@ -17,7 +17,8 @@ packages=netcat-openbsd
 source=file:/tmp/debs ./
 
 [machinekit]
-source=http://deb.machinekit.io/debian
+source=https://dl.cloudsmith.io/public/machinekit/machinekit/deb/debian
+omitdebsrc=true
 suite=stretch
 
 [debian]

--- a/scripts/containers/buildsystem/debian/Dockerfile
+++ b/scripts/containers/buildsystem/debian/Dockerfile
@@ -367,6 +367,14 @@ RUN test -z "$SYS_ROOT" \
 	ln -sf /usr/include.build/x86_64-linux-gnu $SYS_ROOT/usr/include; \
     }
 
+# On Buster, fix krb5-dev .pc files in sysroot
+RUN if test $DISTRO_VER -eq 10 -a -n "$SYS_ROOT"; then \
+        cd /sysroot/usr/lib/${HOST_MULTIARCH}/pkgconfig/mit-krb5 && \
+        for i in *; do \
+	    rm ../$i \
+	    && ln -s mit-krb5/$i ../$i; \
+	done; \
+    fi
 # On Buster, the libczmq.pc file requires libsystemd but the
 # libczmq-dev package doesn't require libsystemd-dev; take care of
 # native case (sysroot case taken care of in multistrap config)

--- a/scripts/containers/buildsystem/debian/Dockerfile
+++ b/scripts/containers/buildsystem/debian/Dockerfile
@@ -87,6 +87,7 @@ RUN apt-get -y install \
 	debian-archive-keyring \
 	python-apt \
 	rubygems \
+    curl \
     && { \
 	test $DISTRO_VER -ge 10 \
 	    || apt-get install -y \
@@ -231,10 +232,11 @@ RUN if test $DISTRO_VER -eq 8; then \
 ###################################################################
 # Machinekit:  Configure apt
 
-# add Machinekit package archive
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 31B5958F43DDF224
-RUN echo "deb http://deb.machinekit.io/debian $DISTRO_CODENAME main" > \
-            /etc/apt/sources.list.d/machinekit.list
+# add Machinekit dependencies package archive
+RUN curl -1sLf \
+  'https://dl.cloudsmith.io/public/machinekit/machinekit/cfg/setup/bash.deb.sh' \
+  | sudo bash \
+  && apt-get update
 
 ###################################################################
 # Machinekit:  Install dependency packages


### PR DESCRIPTION
This pull request is part of the Debian buildsystem rework described in #268:

- Revert commit causing problem with Buster Docker images
- Switch dependency source from MAH.PRIV.AT server to Cloudsmith