### PR TITLE
Rework of buildsystem, part 4

### DIFF
--- a/.github/workflows/debian-builder-workflow.yaml
+++ b/.github/workflows/debian-builder-workflow.yaml
@@ -344,8 +344,8 @@ jobs:
             '--homedir /secrets_mountpoint/.gnupg' --sign builder '{}'
           " > ${ROOT_DIR}/secrets_mountpoint/doSignPackages.sh
           docker run --rm -v "${ROOT_DIR}/secrets_mountpoint:/secrets_mountpoint" \
-            -v "$(pwd):/machinekit-hal" ${DOCKER_IMAGE} /bin/bash \
-            /secrets_mountpoint/doSignPackages.sh
+            -v "$(pwd):/machinekit-hal" -u "$(id -u):$(id -g)" \
+            ${DOCKER_IMAGE} /bin/bash /secrets_mountpoint/doSignPackages.sh
           sudo umount ${ROOT_DIR}/secrets_mountpoint
         env:
           ROOT_DIR: ${{ github.workspace }}

--- a/.github/workflows/debian-builder-workflow.yaml
+++ b/.github/workflows/debian-builder-workflow.yaml
@@ -426,22 +426,48 @@ jobs:
 
       - name: Upload the container image to repository's Github Packages registry
         run: |
+          set +e
           printf "$GITHUB_TOKEN" | docker login docker.pkg.github.com -u ${GITHUB_OWNER} --password-stdin
-          docker push ${IMAGE_NAME_BASE}${TAG}:latest
+          TRY=0
+          while [ $TRY -lt ${MAX_TRIES} ]
+          do
+            (docker push ${IMAGE_NAME_BASE}${TAG}:latest)
+            RETVAL=$?
+            if [ $RETVAL -eq 0 ]; then
+              break
+            fi
+            printf "Docker push exited with %d\nError occured during try %d, trying again\n" "$RETVAL" "$TRY"
+            TRY=$(( $TRY + 1 ))
+          done
+          exit ${RETVAL} 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_OWNER: ${{ github.actor }}
+          MAX_TRIES: 50
           IMAGE_NAME_BASE: 'docker.pkg.github.com/${{ github.repository }}/${{ env.ImageNameRoot }}'
           TAG: '${{ matrix.architecture }}_${{ matrix.osVersionNumber }}'
       
       - name: Upload the container image to third party registry
         if: needs.prepareState.outputs.HasSpecificDockerRegistry == 'true'
         run: |
+          set +e
           printf "$DOCKER_REGISTRY_PASSWORD" | docker login ${DOCKER_REGISTRY_NAME} -u ${DOCKER_REGISTRY_USER} --password-stdin
           docker tag temp/temp:${TAG} ${IMAGE_NAME_BASE}${TAG}:${DOCKER_TAG}
-          docker push ${IMAGE_NAME_BASE}${TAG}:${DOCKER_TAG}
+          TRY=0
+          while [ $TRY -lt ${MAX_TRIES} ]
+          do
+            (docker push ${IMAGE_NAME_BASE}${TAG}:${DOCKER_TAG})
+            RETVAL=$?
+            if [ $RETVAL -eq 0 ]; then
+              break
+            fi
+            printf "Docker push exited with %d\nError occured during try %d, trying again\n" "$RETVAL" "$TRY"
+            TRY=$(( $TRY + 1 ))
+          done
+          exit ${RETVAL}           
         env:
           IMAGE_NAME_BASE: '${{ secrets.DOCKER_REGISTRY_NAME }}/${{ secrets.DOCKER_REGISTRY_PREFIX }}/${{ env.ImageNameRoot }}'
+          MAX_TRIES: 50
           TAG: '${{ matrix.architecture }}_${{ matrix.osVersionNumber }}'
           DOCKER_TAG: '${{ github.sha }}'
           DOCKER_REGISTRY_NAME: ${{ secrets.DOCKER_REGISTRY_NAME }}

--- a/.github/workflows/debian-builder-workflow.yaml
+++ b/.github/workflows/debian-builder-workflow.yaml
@@ -36,12 +36,6 @@ on:
     branches:
     - '*'
 
-env:
-  # DANGER: Changing this value will mean new Docker image name!
-  #         Public Docker images in GitHub Packages cannot be deleted,
-  #         every change will stay visible 'forever' in form of old packages
-  ImageNameRoot: 'machinekit-hal-debian-builder-v.'
-
 jobs:
   prepareState:
     name: Prepare data used in subsequent jobs
@@ -50,10 +44,11 @@ jobs:
       BuildDockerImages: ${{ env.BuildDockerImage }}
       HasCloudsmithToken: ${{ steps.cloudsmith_checker.outputs.tokenPresent }}
       HasSigningKey: ${{ steps.signing_key_checker.outputs.keyPresent }}
-      MainMatrix: ${{ steps.matrix_normalizer.outputs.matrix }}
-      OsVersionsMatrix: ${{ steps.matrix_normalizer.outputs.osMatrix }}
+      MainMatrix: ${{ steps.data_matrix_normalizer.outputs.matrix }}
+      OsVersionsMatrix: ${{ steps.data_matrix_normalizer.outputs.osMatrix }}
       HasSpecificDockerRegistry: ${{ steps.docker_registry_checker.outputs.hasRegistry }}
       Timestamp: ${{ steps.timestamp_exporter.outputs.timestamp }}
+      ImageNameRoot: ${{ steps.data_matrix_normalizer.outputs.imageNameRoot }}
 
     steps:
     - name: Show GitHub context as a JSON
@@ -70,9 +65,13 @@ jobs:
         ref: '${{ github.event.ref }}'
         fetch-depth: '0'
         path: 'machinekit-hal'
-
-    - name: Prepare job matrix for subsequent jobs
-      id: matrix_normalizer
+      
+      # DANGER: Changing value imageNameRoot in settings JSON will mean 
+      #         a new Docker image name!
+      #         Public Docker images in GitHub Packages cannot be deleted,
+      #         every change will stay visible 'forever' in form of old packages  
+    - name: Prepare data and matrix from JSON file used in subsequent jobs
+      id: data_matrix_normalizer
       run: |
         MAIN_MATRIX=$(cat ${BASE_JSON_FILE} | \
           jq -c '{include: [.allowedCombinations[]+.osVersions[] | 
@@ -84,8 +83,12 @@ jobs:
           jq -c '{include: [.include[] | del(.architecture)] | unique}')
         echo "::set-output name=matrix::$MAIN_MATRIX"
         echo "::set-output name=osMatrix::$OS_MATRIX"
-        printf "JSON object for Main Matrix:\n====%s\n" "$MAIN_MATRIX"
-        printf "JSON object for OS Matrix:\n====%s\n" "$OS_MATRIX\n"
+        IMAGE_NAME_ROOT=$(cat ${BASE_JSON_FILE} | \
+          jq -r '.imageNameRoot')
+        echo "::set-output name=imageNameRoot::$IMAGE_NAME_ROOT"
+        printf "JSON object for Main Matrix:\n====\n%s\n" "$MAIN_MATRIX"
+        printf "JSON object for OS Matrix:\n====\n%s\n" "$OS_MATRIX\n"
+        printf "ImageNameRoot for Docker images:\n====\n%s\n" "$IMAGE_NAME_ROOT"
       env:
         BASE_JSON_FILE: './machinekit-hal/scripts/debian-distro-settings.json'
     
@@ -180,7 +183,6 @@ jobs:
         logLevel: debug
         owner: '${{ github.event.repository.owner.login }}'
         repository: '${{ github.event.repository.name }}'
-        inquiry: 'is:public ${{ env.ImageNameRoot }}'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -213,8 +215,8 @@ jobs:
           printf "All images present in registry, no missing packages waiting to be build\n"  
         fi
       env:
-        MATRIX_JSON: '${{ steps.matrix_normalizer.outputs.matrix }}'
-        IMAGE_NAME_ROOT: ${{ env.ImageNameRoot }}
+        MATRIX_JSON: '${{ steps.data_matrix_normalizer.outputs.matrix }}'
+        IMAGE_NAME_ROOT: ${{ steps.data_matrix_normalizer.outputs.imageNameRoot }}
         REPOSITORY_FULL: ${{ github.repository }}
         INPUT_JSON_FILE: 'DockerImagesInGithubPackagesResponse.json'
       
@@ -312,7 +314,7 @@ jobs:
           docker tag ${IMAGE_NAME_BASE}${TAG}:latest temp/temp:${TAG}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGE_NAME_BASE: 'docker.pkg.github.com/${{ github.repository }}/${{ env.ImageNameRoot }}'
+          IMAGE_NAME_BASE: 'docker.pkg.github.com/${{ github.repository }}/${{ needs.prepareState.outputs.ImageNameRoot }}'
           GITHUB_OWNER: ${{ github.actor }}
           TAG: '${{ matrix.architecture }}_${{ matrix.osVersionNumber }}'
         working-directory: ./build/machinekit-hal
@@ -348,7 +350,7 @@ jobs:
         env:
           ROOT_DIR: ${{ github.workspace }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          DOCKER_IMAGE: 'docker.pkg.github.com/${{ github.repository }}/${{ env.ImageNameRoot }}${{ matrix.architecture }}_${{ matrix.osVersionNumber }}:latest'
+          DOCKER_IMAGE: 'docker.pkg.github.com/${{ github.repository }}/${{ needs.prepareState.outputs.ImageNameRoot }}${{ matrix.architecture }}_${{ matrix.osVersionNumber }}:latest'
         working-directory: ./build
 
       - name: Prepare build artifact for upload
@@ -413,7 +415,7 @@ jobs:
           docker tag ${IMAGE_NAME_BASE}${TAG}:latest temp/temp:${TAG}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGE_NAME_BASE: 'docker.pkg.github.com/${{ github.repository }}/${{ env.ImageNameRoot }}'
+          IMAGE_NAME_BASE: 'docker.pkg.github.com/${{ github.repository }}/${{ needs.prepareState.outputs.ImageNameRoot }}'
           GITHUB_OWNER: ${{ github.actor }}
           TAG: '${{ steps.runtime_architecture.outputs.architecture }}_${{ matrix.osVersionNumber }}'
         working-directory: ./build/machinekit-hal
@@ -465,7 +467,7 @@ jobs:
           exit 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGE_NAME_BASE: 'docker.pkg.github.com/${{ github.repository }}/${{ env.ImageNameRoot }}'
+          IMAGE_NAME_BASE: 'docker.pkg.github.com/${{ github.repository }}/${{ needs.prepareState.outputs.ImageNameRoot }}'
           TAG: '${{ matrix.architecture }}_${{ matrix.osVersionNumber }}'
         working-directory: ./build/machinekit-hal
 
@@ -490,7 +492,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_OWNER: ${{ github.actor }}
           MAX_TRIES: 50
-          IMAGE_NAME_BASE: 'docker.pkg.github.com/${{ github.repository }}/${{ env.ImageNameRoot }}'
+          IMAGE_NAME_BASE: 'docker.pkg.github.com/${{ github.repository }}/${{ needs.prepareState.outputs.ImageNameRoot }}'
           TAG: '${{ matrix.architecture }}_${{ matrix.osVersionNumber }}'
       
       - name: Upload the container image to third party registry
@@ -514,7 +516,7 @@ jobs:
           done
           exit ${RETVAL}           
         env:
-          IMAGE_NAME_BASE: '${{ secrets.DOCKER_REGISTRY_NAME }}/${{ secrets.DOCKER_REGISTRY_PREFIX }}/${{ env.ImageNameRoot }}'
+          IMAGE_NAME_BASE: '${{ secrets.DOCKER_REGISTRY_NAME }}/${{ secrets.DOCKER_REGISTRY_PREFIX }}/${{ needs.prepareState.outputs.ImageNameRoot }}'
           MAX_TRIES: 50
           TAG: '${{ matrix.architecture }}_${{ matrix.osVersionNumber }}'
           DOCKER_TAG: '${{ github.sha }}'

--- a/.github/workflows/debian-builder-workflow.yaml
+++ b/.github/workflows/debian-builder-workflow.yaml
@@ -62,7 +62,8 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
 
-      # Fetch the whole history here as there is no way of knowing how many commits there were in push event
+      # Fetch the whole history here as there is no way of knowing how many
+      # commits there were in push event
     - name: Deep clone Machinekit-HAL repository
       uses: actions/checkout@v2
       with:
@@ -73,27 +74,38 @@ jobs:
     - name: Prepare job matrix for subsequent jobs
       id: matrix_normalizer
       run: |
-        MAIN_MATRIX=$(jq -c '{include: [.allowedCombinations[]+.osVersions[] | select(.osVersionNumber == .DISTRO_VER) | {osVersionNumber: .osVersionNumber, architecture: .architecture, osVersionCodename: .DISTRO_CODENAME}]}' ${BASE_JSON_FILE})
-        OS_MATRIX=$(printf "$MAIN_MATRIX" | jq -c '{include: [.include[] | del(.architecture)] | unique}')
+        MAIN_MATRIX=$(cat ${BASE_JSON_FILE} | \
+          jq -c '{include: [.allowedCombinations[]+.osVersions[] | 
+          select(.osVersionNumber == .DISTRO_VER) |
+          {osVersionNumber: .osVersionNumber,
+          architecture: .architecture,
+          osVersionCodename: .DISTRO_CODENAME}]}')
+        OS_MATRIX=$(printf "$MAIN_MATRIX" |  \
+          jq -c '{include: [.include[] | del(.architecture)] | unique}')
         echo "::set-output name=matrix::$MAIN_MATRIX"
         echo "::set-output name=osMatrix::$OS_MATRIX"
-        printf "JSON object for Main Matrix:\n====\n$MAIN_MATRIX\nJSON object for OS Matrix:\n====\n$OS_MATRIX\n"
+        printf "JSON object for Main Matrix:\n====%s\n" "$MAIN_MATRIX"
+        printf "JSON object for OS Matrix:\n====%s\n" "$OS_MATRIX\n"
       env:
         BASE_JSON_FILE: './machinekit-hal/scripts/debian-distro-settings.json'
     
     - name: Get SHAs needed for file changes checking
       id: event_normalizer 
       run: |
-        if [ "${{ github.event_name }}" == "push" ]; then
+        if [ "${{ github.event_name }}" == "push" ]
+        then
           echo "::set-output name=before::${{ github.event.before }}"
           echo "::set-output name=after::${{ github.sha }}"
-          printf "Output ::before set to ${{ github.event.before }}\nOutput ::before set to ${{ github.sha }}\n"
+          printf "Output ::before set to %s\n" "${{ github.event.before }}"
+          printf "Output ::before set to %s\n" "${{ github.sha }}"
           exit 0
         fi
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
+        if [ "${{ github.event_name }}" == "pull_request" ]
+        then
           echo "::set-output name=before::${{ github.event.pull_request.base.sha }}"
           echo "::set-output name=after::${{ github.sha }}"
-          printf "Output ::before set to ${{ github.event.pull_request.base.sha }}\nOutput ::after set to ${{ github.sha }}\n"
+          printf "Output ::before set to %s\n" "${{ github.event.pull_request.base.sha }}"
+          printf "Output ::after set to %s\n" "${{ github.sha }}"
           exit 0
         fi
         printf "Disallowed event type\n"
@@ -106,11 +118,13 @@ jobs:
       # https://github.community/t5/GitHub-Actions/Workflow-paths-on-forced-pushs/m-p/49576
     - name: Check if Docker images related files were changed in this event
       run: |
-        if [[ ${BEFORE} =~ ^0+$ ]]; then
+        if [[ ${BEFORE} =~ ^0+$ ]]
+        then
           printf "This is new branch\n"
           exit 0
         fi
-        if ! git rev-parse -q --verify "$BEFORE^{commit}" > /dev/null; then
+        if ! git rev-parse -q --verify "$BEFORE^{commit}" > /dev/null
+        then
           printf "Commit $BEFORE does not exists, this is probably force push\n"
           exit 0
         fi
@@ -173,18 +187,26 @@ jobs:
     - name: Check if all Debian builder Docker images are present
       if: env.BuildDockerImage != 'true'
       run: |
-        test_array=($(printf "$MATRIX_JSON" | jq -r '.include[] | [.architecture, .osVersionNumber|tostring] | join("_")'))
+        test_array=($(printf "$MATRIX_JSON" | \
+          jq -r '.include[] | [.architecture, .osVersionNumber|tostring] |
+          join("_")'))
         MISSING=0
         for i in ${test_array[@]}
         do
           IMAGENAME="${IMAGE_NAME_ROOT}$i"
-          IMAGESHA=$(jq -r --arg IMAGENAME "$IMAGENAME" '.data.repository.registryPackages.nodes[] | select(.name == $IMAGENAME).version.sha256 | select(.!=null)' ${INPUT_JSON_FILE})
-          if [ -z "$IMAGESHA" ]; then
-            printf "Docker image $IMAGENAME:latest does not exist in registry docker.pkg.github.com/$REPOSITORY_FULL\n"
+          IMAGESHA=$(jq -r --arg IMAGENAME "$IMAGENAME" \
+            '.data.repository.registryPackages.nodes[] |
+            select(.name == $IMAGENAME).version.sha256 |
+            select(.!=null)' ${INPUT_JSON_FILE})
+          if [ -z "$IMAGESHA" ]
+          then
+            printf "Docker image %s:latest does not exist in registry %s\n" \
+            "$IMAGENAME" "docker.pkg.github.com/$REPOSITORY_FULL"
             ((MISSING=MISSING+1))
           fi
         done
-        if [ $MISSING -gt 0 ]; then
+        if [ $MISSING -gt 0 ]
+        then
           printf "Registry is missing $MISSING Docker image(s)\n"
           echo ::set-env name=BuildDockerImage::true
         else
@@ -196,16 +218,19 @@ jobs:
         REPOSITORY_FULL: ${{ github.repository }}
         INPUT_JSON_FILE: 'DockerImagesInGithubPackagesResponse.json'
       
-      # Not Yet Implemented: Check if the :latest Docker image in GitHub Packages is relevant to the current branch
-      #                      by way of implementing a new label in Docker build with SHA of Machinekit-HAL git commit,
-      #                      querying it here in workflow and then check if SHA is in history of this ref before
-      #                      ${{ steps.event_normalizer.outputs.before }} - if not, force rebuild
+      # Not Yet Implemented: 
+      # Check if the :latest Docker image in GitHub Packages is relevant to the 
+      # current branch by way of implementing a new label in Docker build with 
+      # SHA of Machinekit-HAL git commit, querying it here in workflow and then 
+      # check if SHA is in history of this ref before ${{ steps.event_normalizer.outputs.before }},
+      # if not, force rebuild
     
     - name: Check if Cloudsmith authorization token is present in GitHub secrets storage
       if: github.event_name == 'push'
       id: cloudsmith_checker
       run: |
-        if ! [ -z "$CLOUDSMITH_TOKEN" ]; then
+        if ! [ -z "$CLOUDSMITH_TOKEN" ]
+        then
           printf "Cloudsmith.io authorization token found in GitHub secret storage, will try to upload\n"
           echo "::set-output name=tokenPresent::true"
         else
@@ -219,7 +244,8 @@ jobs:
       if: github.event_name == 'push'
       id: signing_key_checker
       run: |
-        if ! [ -z "$SIGNING_KEY" ]; then
+        if ! [ -z "$SIGNING_KEY" ]
+        then
           printf "Signing key found in GitHub secret storage, will try to sign\n"
           echo "::set-output name=keyPresent::true"
         else
@@ -233,7 +259,9 @@ jobs:
       if: env.BuildDockerImage == 'true' && github.event_name == 'push'
       id: docker_registry_checker
       run: |
-        if [ -n "$DOCKER_REGISTRY_NAME" -a -n "$DOCKER_REGISTRY_USER" -a -n "$DOCKER_REGISTRY_PASSWORD" -a -n "$DOCKER_REGISTRY_PREFIX" ]; then
+        if [ -n "$DOCKER_REGISTRY_NAME" -a -n "$DOCKER_REGISTRY_USER" -a -n \
+          "$DOCKER_REGISTRY_PASSWORD" -a -n "$DOCKER_REGISTRY_PREFIX" ]
+        then
           printf "Docker Registry data found in GitHub secret storage, will try to upload\n"
           echo "::set-output name=hasRegistry::true"
         else
@@ -268,15 +296,18 @@ jobs:
           ref: '${{ github.event.ref }}'
           path: 'build/machinekit-hal'
 
-        # Docker image temp/temp is temporary until the build script is changed accordingly
+        # Docker image temp/temp is temporary until the build script is changed
+        # accordingly
       - name: Prepare the Docker image
         run: |
-          if [ "${{ needs.prepareState.outputs.BuildDockerImages }}" == "true" ]; then
+          if [ "${{ needs.prepareState.outputs.BuildDockerImages }}" == "true" ]
+          then
             scripts/build_debian_docker_image -r temp -i temp -t ${TAG}
             docker tag temp/temp:${TAG} ${IMAGE_NAME_BASE}${TAG}:latest
             exit 0
           fi
-          printf "${{ env.GITHUB_TOKEN}}" | docker login docker.pkg.github.com -u $GITHUB_OWNER --password-stdin
+          printf "${{ env.GITHUB_TOKEN}}" | docker login docker.pkg.github.com \
+            -u $GITHUB_OWNER --password-stdin
           docker pull ${IMAGE_NAME_BASE}${TAG}:latest
           docker tag ${IMAGE_NAME_BASE}${TAG}:latest temp/temp:${TAG}
         env:
@@ -286,7 +317,8 @@ jobs:
           TAG: '${{ matrix.architecture }}_${{ matrix.osVersionNumber }}'
         working-directory: ./build/machinekit-hal
 
-        # Docker image temp/temp is temporary until the build script is changed accordingly
+        # Docker image temp/temp is temporary until the build script is changed
+        # accordingly
       - name: Build Machinekit-HAL Debian package for ${{ matrix.osVersionCodename}}, ${{ matrix.architecture }}
         run: |
           scripts/build_docker -i $DOCKER_IMAGE -t $TAG -c deb -n
@@ -303,10 +335,15 @@ jobs:
           echo "$SIGNING_KEY" > ${ROOT_DIR}/secrets_mountpoint/key.gpg
           echo "
           #!/bin/bash -e
-          gpg --homedir /secrets_mountpoint/.gnupg -v --batch --import '/secrets_mountpoint/key.gpg'
-          find /machinekit-hal -maxdepth 1 -name *.deb -print0 | xargs -0 -n1 -t -I '{}' dpkg-sig --gpg-options '--homedir /secrets_mountpoint/.gnupg' --sign builder '{}'
+          gpg --homedir /secrets_mountpoint/.gnupg -v --batch --import \
+            '/secrets_mountpoint/key.gpg'
+          find /machinekit-hal -maxdepth 1 -name *.deb -print0 | \
+            xargs -0 -n1 -t -I '{}' dpkg-sig --gpg-options \
+            '--homedir /secrets_mountpoint/.gnupg' --sign builder '{}'
           " > ${ROOT_DIR}/secrets_mountpoint/doSignPackages.sh
-          docker run --rm -v "${ROOT_DIR}/secrets_mountpoint:/secrets_mountpoint" -v "$(pwd):/machinekit-hal" ${DOCKER_IMAGE} /bin/bash /secrets_mountpoint/doSignPackages.sh
+          docker run --rm -v "${ROOT_DIR}/secrets_mountpoint:/secrets_mountpoint" \
+            -v "$(pwd):/machinekit-hal" ${DOCKER_IMAGE} /bin/bash \
+            /secrets_mountpoint/doSignPackages.sh
           sudo umount ${ROOT_DIR}/secrets_mountpoint
         env:
           ROOT_DIR: ${{ github.workspace }}
@@ -317,10 +354,13 @@ jobs:
       - name: Prepare build artifact for upload
         run: |
           mkdir machinekit-hal-debian
-          find ./build -depth -not \( -path "." -or -path "./build" -or -path "./build/machinekit-hal" -or -path "./build/machinekit-hal/*" \) -print0 | xargs -0 -t -I '{}' cp -v '{}' ./machinekit-hal-debian
+          find ./build -depth -not \( \
+          -path "." -or -path "./build" -or -path "./build/machinekit-hal" -or \
+          -path "./build/machinekit-hal/*" \) -print0 | \
+          xargs -0 -t -I '{}' cp -v '{}' ./machinekit-hal-debian
 
       - name: Upload built package for Debian ${{ matrix.osVersionCodename}}, ${{ matrix.architecture }} as an artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: machinekit-hal-debian-${{ matrix.architecture }}-${{ matrix.osVersionNumber }}-${{ github.sha }}-${{ needs.prepareState.outputs.Timestamp }}
           path: machinekit-hal-debian
@@ -357,15 +397,18 @@ jobs:
           printf "This job is going to use $RENAMEARCH as an achitecture tag\n"
           echo "::set-output name=architecture::$RENAMEARCH"
 
-        # Docker image temp/temp is temporary until the build script is changed accordingly
+        # Docker image temp/temp is temporary until the build script is changed
+        # accordingly
       - name: Prepare the Docker image
         run: |
-          if [ "${{ needs.prepareState.outputs.BuildDockerImages }}" == "true" ]; then
+          if [ "${{ needs.prepareState.outputs.BuildDockerImages }}" == "true" ]
+          then
             scripts/build_debian_docker_image -r temp -i temp -t ${TAG}
             docker tag temp/temp:${TAG} ${IMAGE_NAME_BASE}${TAG}:latest
             exit 0
           fi
-          printf "${{ env.GITHUB_TOKEN}}" | docker login docker.pkg.github.com -u $GITHUB_OWNER --password-stdin
+          printf "${{ env.GITHUB_TOKEN}}" | \
+          docker login docker.pkg.github.com -u $GITHUB_OWNER --password-stdin
           docker pull ${IMAGE_NAME_BASE}${TAG}:latest
           docker tag ${IMAGE_NAME_BASE}${TAG}:latest temp/temp:${TAG}
         env:
@@ -375,7 +418,8 @@ jobs:
           TAG: '${{ steps.runtime_architecture.outputs.architecture }}_${{ matrix.osVersionNumber }}'
         working-directory: ./build/machinekit-hal
 
-        # Docker image temp/temp is temporary until the build script is changed accordingly
+        # Docker image temp/temp is temporary until the build script is changed
+        # accordingly
       - name: Execute Runtests
         run: |
           scripts/build_docker -i $DOCKER_IMAGE -t $TAG -c test
@@ -390,12 +434,13 @@ jobs:
       - name: Execute Python nosetests
         run: printf "Not yet implemented\n"
 
-  # This has a chance to cause problems when developing multiple branches simultaneously
-  # all or some of which use different builder configuration, one way how to solve it is 
-  # to use different tags for different branches, but with the current state with Github
-  # Packages when one cannot delete public packages (there is discussion on github.community
-  # it will be) and fact that Github doesn't say how much space is available for Open Source
-  # repository, I am going to let it be limited to :latest for now
+  # This has a chance to cause problems when developing multiple branches 
+  # simultaneously all or some of which use different builder configuration,
+  # one way how to solve it is to use different tags for different branches, 
+  # but with the current state with Github Packages when one cannot delete 
+  # public packages (there is discussion on github.community it will be) 
+  # and fact that Github doesn't say how much space is available for Open
+  # Source repository, I am going to let it be limited to :latest for now
   buildContainerImagesForUpload:
     name: Build and upload Machinekit HAL builder Docker image for Debian ${{ matrix.osVersionCodename }}, ${{ matrix.architecture }}
     runs-on: ubuntu-latest
@@ -427,7 +472,8 @@ jobs:
       - name: Upload the container image to repository's Github Packages registry
         run: |
           set +e
-          printf "$GITHUB_TOKEN" | docker login docker.pkg.github.com -u ${GITHUB_OWNER} --password-stdin
+          printf "$GITHUB_TOKEN" | docker login docker.pkg.github.com \
+            -u ${GITHUB_OWNER} --password-stdin
           TRY=0
           while [ $TRY -lt ${MAX_TRIES} ]
           do
@@ -451,7 +497,9 @@ jobs:
         if: needs.prepareState.outputs.HasSpecificDockerRegistry == 'true'
         run: |
           set +e
-          printf "$DOCKER_REGISTRY_PASSWORD" | docker login ${DOCKER_REGISTRY_NAME} -u ${DOCKER_REGISTRY_USER} --password-stdin
+          printf "$DOCKER_REGISTRY_PASSWORD" | \
+            docker login ${DOCKER_REGISTRY_NAME} -u ${DOCKER_REGISTRY_USER} \
+            --password-stdin
           docker tag temp/temp:${TAG} ${IMAGE_NAME_BASE}${TAG}:${DOCKER_TAG}
           TRY=0
           while [ $TRY -lt ${MAX_TRIES} ]
@@ -491,7 +539,7 @@ jobs:
         working-directory: ./artifacts
       
       - name: Prepare specific Python version for Cloudsmith CLI
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: '3.8'
 
@@ -507,22 +555,38 @@ jobs:
         run: |
           test_array=()
           CLOUDSMITH_REPLY=$(cloudsmith list repos --output-format json)
-          FOUND_NAMESPACE=$(echo "$CLOUDSMITH_REPLY" | jq -e -r --arg INPUTREGEX "$REPOSITORY_REGEX" '.data[] | select(.slug|test($INPUTREGEX)) | .namespace')
-          FOUND_REPOSITORY=$(echo "$CLOUDSMITH_REPLY" | jq -e -r --arg INPUTREGEX "$REPOSITORY_REGEX" '.data[] | select(.slug|test($INPUTREGEX)) | .slug')
-          if [ "$FOUND_REPOSITORY" == "" -o "$FOUND_REPOSITORY" == "null" -o "$FOUND_NAMESPACE" == "" -o "$FOUND_NAMESPACE" == "null" ]
+          FOUND_NAMESPACE=$(echo "$CLOUDSMITH_REPLY" | \
+            jq -e -r --arg INPUTREGEX "$REPOSITORY_REGEX" '.data[] | 
+            select(.slug|test($INPUTREGEX)) | .namespace')
+          FOUND_REPOSITORY=$(echo "$CLOUDSMITH_REPLY" | \
+            jq -e -r --arg INPUTREGEX "$REPOSITORY_REGEX" '.data[] | 
+            select(.slug|test($INPUTREGEX)) | .slug')
+          if [ "$FOUND_REPOSITORY" == "" -o "$FOUND_REPOSITORY" == "null" \
+            -o "$FOUND_NAMESPACE" == "" -o "$FOUND_NAMESPACE" == "null" ]
           then
-            printf "No repository matching regular expression %s found\n" "$REPOSITORY_REGEX"
+            printf "No repository matching regular expression %s found\n" \
+              "$REPOSITORY_REGEX"
             exit 1
           fi
-          printf "Found repository %s/%s in Cloudsmith account\n" "$FOUND_NAMESPACE" "$FOUND_REPOSITORY"
+          printf "Found repository %s/%s in Cloudsmith account\n" \
+            "$FOUND_NAMESPACE" \
+            "$FOUND_REPOSITORY"
           while IFS=  read -r -d $'\0'; do
             test_array+=("$REPLY")
-          done < <(find . -type f -regextype egrep -iregex "${PACKAGES_REGEX}" -print0)
+          done < <(find . -type f -regextype egrep \
+            -iregex "${PACKAGES_REGEX}" -print0)
           for package in "${test_array[@]}"
           do
             [[ "$package" =~ $PACKAGES_REGEX ]]
-            OSCODENAME=$(echo "$MATRIX_JSON" | jq -r --arg OSVERSIONNUMBER "${BASH_REMATCH[2]}" --arg ARCHITECTURE "${BASH_REMATCH[1]}" '.include[] | select((.osVersionNumber|tostring==$OSVERSIONNUMBER) and (.architecture==$ARCHITECTURE)) | .osVersionCodename')
-            cloudsmith push deb ${FOUND_NAMESPACE}/${FOUND_REPOSITORY}/debian/${OSCODENAME} ${package} --republish
+            OSCODENAME=$(echo "$MATRIX_JSON" | \
+              jq -r --arg OSVERSIONNUMBER "${BASH_REMATCH[2]}" \
+              --arg ARCHITECTURE "${BASH_REMATCH[1]}" \
+              '.include[] | select((.osVersionNumber|tostring==$OSVERSIONNUMBER)
+              and (.architecture==$ARCHITECTURE)) | .osVersionCodename')
+            cloudsmith push deb \
+              ${FOUND_NAMESPACE}/${FOUND_REPOSITORY}/debian/${OSCODENAME} \
+              ${package} \
+              --republish
           done
         env:
           MATRIX_JSON: '${{ needs.prepareState.outputs.MainMatrix }}'

--- a/scripts/containers/buildsystem/debian/Dockerfile
+++ b/scripts/containers/buildsystem/debian/Dockerfile
@@ -403,15 +403,34 @@ RUN if test $DISTRO_VER -eq 10 -a -z "$SYS_ROOT"; then \
 
 ###########################################
 # Set up environment
-#
+
+RUN echo "ALL ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+RUN addgroup --gid 1000 machinekit && \
+    adduser --uid 1000 --ingroup machinekit \
+        --home /home/machinekit --shell /bin/bash \
+        --disabled-password --gecos "" machinekit
+
+RUN USER=machinekit && \ 
+    GROUP=machinekit && \
+    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4.1/fixuid-0.4.1-linux-amd64.tar.gz | \
+        tar -C /usr/local/bin -xzf - && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+
+USER machinekit
+
 # Customize the following to match the user's environment
 
-ENV SHELL=/bin/bash
-ENV PATH=/usr/lib/ccache:/opt/gcc-linaro-hf/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH=/usr/lib/ccache:/opt/gcc-linaro-hf/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH}
 
 # Customize the run environment to your taste
 # - bash prompt
 # - 'ls' alias
-RUN sed -i /etc/bash.bashrc \
+RUN sed -i ~/.bashrc \
     -e 's/^PS1=.*/PS1="\\h:\\W\\$ "/' \
     -e '$a alias ls="ls -aFs"'
+
+ENTRYPOINT ["fixuid"]

--- a/scripts/containers/buildsystem/debian/Dockerfile
+++ b/scripts/containers/buildsystem/debian/Dockerfile
@@ -126,6 +126,8 @@ RUN apt-get install -y \
 	psmisc \
 	pkg-config \
 	qemu-user-static \
+    libcmocka-dev \
+    python-nose \
 	linux-libc-dev:${DEBIAN_ARCH} \
         dh-python \
 	libreadline-dev \

--- a/scripts/debian-distro-settings.json
+++ b/scripts/debian-distro-settings.json
@@ -96,5 +96,6 @@
             "osVersionNumber": 10,
             "architecture": "arm64"
         }
-    ]
+    ],
+    "imageNameRoot": "machinekit-hal-debian-builder-v."
 }


### PR DESCRIPTION
This pull request implements the signing of packages as described in #268.

New functionality includes:
- Hammering in newly built Docker images to GitHub Packages Docker registry in loop until successful (tried 50 times, usually successful in tests on second or third test)
- Hammering in newly built Docker images to 3th party registry (just in case, DockerHUB had similar problem in the past, they say)
- Housekeeping task of limiting characters on line requested by @zultron in #276
- The name source for Debian builder Docker images transferred to `debian-distro-settings.json`
- All tested on Machinekit/Machinekit-HAL side with adding dependency to Docker image on `libcmocka-dev` and `python-nose` 