### PR TITLE
Remove `rtapi_get_rpath()` function

### DIFF
--- a/src/rtapi/rtapi_app.cc
+++ b/src/rtapi/rtapi_app.cc
@@ -163,7 +163,6 @@ static char flavor_name_opt[MAX_FLAVOR_NAME_LEN] = {0};
 // global_data is set in attach_global_segment() which was already
 // created by rtapi_msgd
 global_data_t *global_data;
-static const char *rpath;
 static int init_actions(int instance);
 static void exit_actions(int instance);
 static int harden_rt(void);
@@ -547,7 +546,6 @@ static int do_load_cmd(int instance,
 
     if (mi.load(path) != 0) {
         note_printf(pbreply, "%s: %s", __FUNCTION__, mi.errmsg);
-        note_printf(pbreply, "rpath=%s", rpath == NULL ? "" : rpath);
         return -1;
     }
 
@@ -1081,7 +1079,6 @@ static int mainloop(size_t  argc, char **argv)
 	memset(argv[i], '\0', strlen(argv[i]));
 
     backtrace_init(proctitle);
-    rpath = rtapi_get_rpath();
 
     // set this thread's name so it can be identified in ps/top as
     // rtapi:<instance>
@@ -1616,15 +1613,11 @@ static void remove_module(std::string name)
 // are applied.
 static int record_instparms(Module &mi)
 {
-    if (rpath == NULL)
-	return -1;
-
     void *section = NULL;
     int csize = -1;
     size_t i;
     vector<string> tokens;
     string pn;
-    string rp(rpath);
 
     csize = mi.elf_section(".rtapi_export" , &section);
     if (csize < 0) {

--- a/src/rtapi/rtapi_compat.c
+++ b/src/rtapi/rtapi_compat.c
@@ -151,25 +151,6 @@ int rtapi_fs_read(char *buf, const size_t maxlen, const char *name, ...)
     }
 }
 
-const char *rtapi_get_rpath(void)
-{
-  const ElfW(Dyn) *dyn = _DYNAMIC;
-  const ElfW(Dyn) *rpath = NULL;
-  const char *strtab = NULL;
-  for (; dyn->d_tag != DT_NULL; ++dyn) {
-    if (dyn->d_tag == DT_RPATH) {
-      rpath = dyn;
-    } else if (dyn->d_tag == DT_STRTAB) {
-      strtab = (const char *)dyn->d_un.d_val;
-    }
-  }
-
-  if (strtab != NULL && rpath != NULL) {
-      return strdup(strtab + rpath->d_un.d_val);
-  }
-  return NULL;
-}
-
 int get_elf_section(const char *const fname, const char *section_name, void **dest)
 {
     int size = -1, i;

--- a/src/rtapi/rtapi_compat.h
+++ b/src/rtapi/rtapi_compat.h
@@ -61,14 +61,6 @@ int rtapi_fs_read(char *buf, const size_t maxlen, const char *name, ...);
 
 extern int get_rtapi_config(char *result, const char *param, int n);
 
-// diagnostics: retrieve the rpath this binary was linked with
-//
-// returns malloc'd memory - caller MUST free returned string if non-null
-// example:  cc -g -Wall -Wl,-rpath,/usr/local/lib -Wl,-rpath,/usr/lib foo.c -o foo
-// rtapi_get_rpath() will return "/usr/local/lib:/usr/lib"
-
-extern const char *rtapi_get_rpath(void);
-
 // inspection of Elf objects (.so, .ko):
 // retrieve raw data of Elf section section_name.
 // returned in *dest on success.


### PR DESCRIPTION
This cleans up `rtapi_get_rpath()`, no longer needed after 7912ef18,
"Abstract module loading".