### PR TITLE
Aarch64 tests compability fix

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -444,7 +444,6 @@ HEADERS := \
     hal/lib/hal_logging.h \
     hal/lib/hal_object.h \
     hal/lib/hal_object_selectors.h \
-    hal/lib/hal_parport.h \
     hal/lib/hal_priv.h \
     hal/lib/hal_rcomp.h \
     hal/lib/hal_ring.h \
@@ -517,7 +516,6 @@ HEADERS := \
     rtapi/rtapi_exception.h \
     rtapi/rtapi_global.h \
     rtapi/rtapi_shmkeys.h \
-    rtapi/rtapi_io.h \
     rtapi/rtapi_errno.h \
     rtapi/rtapi_string.h \
     rtapi/rtapi_pci.h \
@@ -533,7 +531,11 @@ HEADERS := \
     rtapi/flavor/rt-preempt.h \
     rtapi/flavor/ulapi.h
 
-
+ifeq ($(HAS_SYS_IO),yes)
+    HEADERS += \
+		hal/lib/hal_parport.h \
+		rtapi/rtapi_io.h
+endif
 
 ## the "headers" target installs all the header files in ../include
 .PHONY: headers

--- a/src/rtapi/rtapi_msgd.cc
+++ b/src/rtapi/rtapi_msgd.cc
@@ -82,7 +82,7 @@ using namespace google::protobuf;
 // default size of the thread stack size passed to rtapi_task_new()
 // in hal_create_thread()
 // can be overridden by an option to rtapi_msgd
-#define HAL_STACKSIZE           32768
+#define HAL_STACKSIZE 262144
 
 
 #ifndef SYSLOG_FACILITY

--- a/tests/build/header-sanity/test.sh
+++ b/tests/build/header-sanity/test.sh
@@ -1,21 +1,23 @@
 #!/bin/sh
-set -xe 
-HEADERS=$(readlink -f ../../../include)
-for i in $HEADERS/*.h; do
-    case $i in
+set -xe
+# Change to "mapfile -d ''" and "realpath -e -z" with multiline support after
+# Jessie is dropped
+HEADERS_DIRECTORY=$(readlink -f ../../include)
+mapfile -t ARRAY_H_HH < <(find ${HEADERS_DIRECTORY} -type f \
+    \( -iname \*.h -o -iname \*.hh \) -print0 | \
+    xargs -0 -n1 -I '{}' readlink -f '{}')
+
+for HEADER in "${ARRAY_H_HH[@]}"
+do
+    case ${HEADER} in
     */rtapi_app.h) continue ;;
     */rtapi_common.h) continue ;;
     */*.pb.h) continue ;;
     */container.h) continue ;;
     esac
-    gcc -DULAPI -I$HEADERS -E -x c $i > /dev/null
-done
-for i in $HEADERS/*.h $HEADERS/*.hh; do
-    case $i in
-    */rtapi_app.h) continue ;;
-    */rtapi_common.h) continue ;;
-    */*.pb.h) continue ;;
-    */container.h) continue ;;
-    esac
-    g++ -DULAPI -I$HEADERS -E -x c++ $i > /dev/null
+    if [ "${HEADER: -2}" == ".h" ]
+    then
+        gcc -DULAPI -I${HEADERS_DIRECTORY} -E -x c ${HEADER} > /dev/null
+    fi
+    g++ -DULAPI -I${HEADERS_DIRECTORY} -E -x c++ ${HEADER} > /dev/null
 done


### PR DESCRIPTION
This pull request contains compability fixes to allow `runtests` to pass on real `aarch64` hardware (so far tested on [Drone cloud](https://cloud.drone.io)) as described in **issues** #96 and #268.

Changes are:
- Raise `HAL_STACKSIZE` to 335872 globally to avoid the `PTHREAD_STACK_MIN` error. I chose to use `(4 * PAGE_SIZE)` with 64k `PAGE_SIZE` - trying to encompass all variants. If anybody sees a problem with this, post a comment.
- Conditionally include header files in *src/Makefile* based on `HAS_SYS_IO`
- Rewrite `header-sanity` test so it doesn't fail on:
```
+ runtests -v sanitytest
Running test: sanitytest/header-sanity
+ set -xe
++ readlink -f ../../../include
+ HEADERS=/home/machinekit/include
+ for i in $HEADERS/*.h
+ case $i in
+ gcc -DULAPI -I/home/machinekit/include -E -x c '/home/machinekit/include/*.h'
gcc: error: /home/machinekit/include/*.h: No such file or directory
gcc: warning: '-x c' after last input file has no effect
gcc: fatal error: no input files
compilation terminated.
*** sanitytest/header-sanity: FAIL: test run exited with 1
Runtest: 1 tests run, 0 successful, 1 failed + 0 expected
Failed: 
	sanitytest/header-sanity
```

It would be great if @the-snowwhite could test this (build and `runtests tests`) on real hardware.

This **does not** fix issues when running Machinekit-HAL in **QEMU** on `amd64`.