### PR TITLE
Aarch64 tests compability fix, follow up bugfix

### DIFF
--- a/tests/build/header-sanity/test.sh
+++ b/tests/build/header-sanity/test.sh
@@ -2,10 +2,20 @@
 set -xe
 # Change to "mapfile -d ''" and "realpath -e -z" with multiline support after
 # Jessie is dropped
-HEADERS_DIRECTORY=$(readlink -f ../../include)
+HEADERS_DIRECTORY=$(readlink -f ../../../include)
 mapfile -t ARRAY_H_HH < <(find ${HEADERS_DIRECTORY} -type f \
     \( -iname \*.h -o -iname \*.hh \) -print0 | \
     xargs -0 -n1 -I '{}' readlink -f '{}')
+
+if (( ${#ARRAY_H_HH[@]} <= 5 )); then
+    printf "Found %d header files:\n===\n" ${#ARRAY_H_HH[@]}
+    for FILE in "${ARRAY_H_HH[@]}"
+    do
+        printf "FILE: %s\n" "$FILE"
+    done
+    printf "This seems too low number\n"
+    exit 2
+fi
 
 for HEADER in "${ARRAY_H_HH[@]}"
 do


### PR DESCRIPTION
This pull request fixes up my error introduced in #286: `HEADERS_DIRECTORY=$(readlink -f ../../include)` instead of `HEADERS_DIRECTORY=$(readlink -f ../../../include)`

Also added is condition (at least five found header files) which should protect against such errors and should make the test fail when suspicious number of headers is found (i.e. 0 in most cases).