### PR TITLE
GH workflows:  Make name of runs readable in webpage

### DIFF
--- a/.github/workflows/debian-builder-workflow.yaml
+++ b/.github/workflows/debian-builder-workflow.yaml
@@ -312,8 +312,8 @@ jobs:
 
   buildMachinekitHALDebianPackages:
     name: >
-      Build Machinekit HAL packages for ${{ matrix.osDistribution }}
-      ${{ matrix.osVersionCodename }}, ${{ matrix.architecture }}
+      Package ${{ matrix.osDistribution }} ${{ matrix.osVersionCodename }},
+      ${{ matrix.architecture }}
     runs-on: ubuntu-latest
     needs: prepareState
     strategy:
@@ -461,8 +461,7 @@ jobs:
 
   testMachinekitHALBuild:
     name: >
-      Test Machinekit HAL code on ${{ matrix.osDistribution }}
-      ${{ matrix.osVersionCodename }}
+      Test ${{ matrix.osDistribution }} ${{ matrix.osVersionCodename }}
     runs-on: ubuntu-latest
     needs: prepareState
     strategy:


### PR DESCRIPTION
The names of the runs are so long that on the GH actions "runs" page,
list items on the left are truncated, with the interesting ones
reading, "Build Machinekit HAL packages ..." and "Test Machinekit HAL
on D...".

The interesting information is the type of run ("Build", "Test"), the
OS vendor ("Debian", "Ubuntu"), the code name ("Stretch", "Focal"),
and the architecture ("amd64", "armhf").

This patch shortens the run descriptions to remove unneeded
information so that the important information is visible.