### PR TITLE
halmodule:  Add S64 and U64 types; rework number conversion

### DIFF
--- a/tests/halmodule.0/expected
+++ b/tests/halmodule.0/expected
@@ -1,35 +1,83 @@
-set s -1 ok
-set s 0 ok
-set s 1 ok
-set s 2147483647 ok
-set s -2147483648 ok
-part 2
-set u 0 ok
-set u 1 ok
-set u 4294967295 ok
-part 3
-set f 0 ok
-set f 0.0 ok
-set f -1 ok
-set f -1.0 ok
-set f 1 ok
-set f 1.0 ok
-part 4
-set f 89884656743115795386465259539451236680898848947115328636715040578866337902750481566354238661203768010560056939935696678829394884407208311246423715319737062188883946712432742638151109800623047059726541476042502884419075341171231440736956555270413618581675255342293149119973622969239858152417678164812112068608 ok
-part 5
-set s 2147483648 OverflowError: Value 2147483648 out of range
-set s -2147483649 OverflowError: Value -2147483649 out of range
-part 6
-set u -1 OverflowError: can't convert negative int to unsigned
-set u 4294967296 OverflowError: Value 4294967296 out of range
-part 7
-set f 179769313486231590772930519078902473361797697894230657273430081157732675805500963132708477322407536021120113879871393357658789768814416622492847430639474124377767893424865485276302219601246094119453082952085005768838150682342462881473913110540827237163350510684586298239947245938479716304835356329624224137216 OverflowError: int too large to convert to float
-pincheck s True True True
-pincheck u True True True
-pincheck f True True True
-pincheck s True True True
+S32 pass
+set HAL_S32 -1 ok
+set HAL_S32 0 ok
+set HAL_S32 1 ok
+set HAL_S32 2147483647 ok
+set HAL_S32 -2147483648 ok
+set HAL_S32 100000.0 ok
+set HAL_S32 99.99 99
+set HAL_S32 True ok
+S32 fail
+set HAL_S32 2147483648 OverflowError: Python int too large to convert to C long
+set HAL_S32 -2147483649 OverflowError: Python int too large to convert to C long
+set HAL_S32 1.98225e+50 OverflowError: Python int too large to convert to C long
+set HAL_S32 foo TypeError: Failed to convert str('foo') to int type
+set HAL_S32 None TypeError: Failed to convert NoneType(None) to int type
+U32 pass
+set HAL_U32 0 ok
+set HAL_U32 1 ok
+set HAL_U32 4294967295 ok
+set HAL_U32 100000.0 ok
+set HAL_U32 99.99 99
+set HAL_U32 True ok
+U32 fail
+set HAL_U32 -1 OverflowError: can't convert negative value to unsigned int
+set HAL_U32 4294967296 OverflowError: Python int too large to convert to C unsigned long
+set HAL_U32 1.98225e+50 OverflowError: Python int too large to convert to C unsigned long
+set HAL_U32 foo TypeError: Failed to convert str('foo') to int type
+set HAL_U32 None TypeError: Failed to convert NoneType(None) to int type
+S64 pass
+set HAL_S64 -1 ok
+set HAL_S64 0 ok
+set HAL_S64 1 ok
+set HAL_S64 9223372036854775807 ok
+set HAL_S64 -9223372036854775808 ok
+set HAL_S64 1000000000000000.0 ok
+set HAL_S64 99.99 99
+set HAL_S64 True ok
+S64 fail
+set HAL_S64 9223372036854775808 OverflowError: int too big to convert
+set HAL_S64 -9223372036854775809 OverflowError: int too big to convert
+set HAL_S64 foo TypeError: Failed to convert str('foo') to int type
+set HAL_S64 None TypeError: Failed to convert NoneType(None) to int type
+U64 pass
+set HAL_U64 0 ok
+set HAL_U64 1 ok
+set HAL_U64 18446744073709551615 ok
+set HAL_U64 1000000000000000.0 ok
+set HAL_U64 99.99 99
+set HAL_U64 True ok
+U64 fail
+set HAL_U64 -1 OverflowError: can't convert negative int to unsigned
+set HAL_U64 18446744073709551616 OverflowError: int too big to convert
+set HAL_U64 foo TypeError: Failed to convert str('foo') to int type
+set HAL_U64 None TypeError: Failed to convert NoneType(None) to int type
+FLOAT pass
+set HAL_FLOAT 0 ok
+set HAL_FLOAT 0.0 ok
+set HAL_FLOAT -1 ok
+set HAL_FLOAT -1.0 ok
+set HAL_FLOAT 1 ok
+set HAL_FLOAT 1.0 ok
+set HAL_FLOAT 89884656743115795386465259539451236680898848947115328636715040578866337902750481566354238661203768010560056939935696678829394884407208311246423715319737062188883946712432742638151109800623047059726541476042502884419075341171231440736956555270413618581675255342293149119973622969239858152417678164812112068608 ok
+FLOAT fail
+set HAL_FLOAT 179769313486231590772930519078902473361797697894230657273430081157732675805500963132708477322407536021120113879871393357658789768814416622492847430639474124377767893424865485276302219601246094119453082952085005768838150682342462881473913110540827237163350510684586298239947245938479716304835356329624224137216 OverflowError: int too large to convert to float
+set HAL_FLOAT foo TypeError: Failed to convert str('foo') to float type
+set HAL_FLOAT None TypeError: Failed to convert NoneType(None) to float type
+Validate pins
+pincheck direct HAL_FLOAT True True True
+pincheck getitem HAL_FLOAT True True True
+pincheck direct HAL_S32 True True True
+pincheck getitem HAL_S32 True True True
+pincheck direct HAL_S64 True True True
+pincheck getitem HAL_S64 True True True
+pincheck direct HAL_U32 True True True
+pincheck getitem HAL_U32 True True True
+pincheck direct HAL_U64 True True True
+pincheck getitem HAL_U64 True True True
 getitem not-found fail
-pincheck param False True True
-pincheck param False True True
-setpin u 0 0
-setpin u -1 OverflowError: can't convert negative int to unsigned
+pincheck direct param False True True
+pincheck getitem param False True True
+Validate set/get
+setpin HAL_U32 0 0
+setpin HAL_U32 -1 OverflowError: can't convert negative value to unsigned int

--- a/tests/halmodule.0/test.py
+++ b/tests/halmodule.0/test.py
@@ -4,22 +4,128 @@ import os
 
 h = hal.component("x")
 try:
-    ps = h.newpin("s", hal.HAL_S32, hal.HAL_OUT)
-    pu = h.newpin("u", hal.HAL_U32, hal.HAL_OUT)
-    pf = h.newpin("f", hal.HAL_FLOAT, hal.HAL_OUT)
+    pins = dict(
+        HAL_S32 = h.newpin("HAL_S32", hal.HAL_S32, hal.HAL_OUT),
+        HAL_U32 = h.newpin("HAL_U32", hal.HAL_U32, hal.HAL_OUT),
+        HAL_S64 = h.newpin("HAL_S64", hal.HAL_S64, hal.HAL_OUT),
+        HAL_U64 = h.newpin("HAL_U64", hal.HAL_U64, hal.HAL_OUT),
+        HAL_FLOAT = h.newpin("HAL_FLOAT", hal.HAL_FLOAT, hal.HAL_OUT)
+    )
     param = h.newparam("param", hal.HAL_BIT, hal.HAL_RW)
     h.ready()
 
+    ########## Set and read pin values; access pins via hal.compenent.__getitem__()
     def try_set(p, v):
         try:
             h[p] = v
             hp = h[p]
             print("set {} {} {}".format(p, v, "ok" if hp == v else repr(hp)))
-        except ValueError as e:
-            print("set {} {} {}".format(p, v, "ValueError: %s" % e))
-        except OverflowError as e:
-            print("set {} {} {}".format(p, v, "OverflowError: %s" % e))
+        except Exception as e:
+            print("set {} {} {}: {}".format(p, v, type(e).__name__, e))
 
+    print("S32 pass")
+    # pass
+    try_set("HAL_S32", -1)
+    try_set("HAL_S32", 0)
+    try_set("HAL_S32", 1)
+    try_set("HAL_S32", 0x7fffffff) # INT32_MAX
+    try_set("HAL_S32", -0x80000000) # INT32_MIN
+    try_set("HAL_S32", 1e5) # float
+    try_set("HAL_S32", 99.99) # float, int part
+    try_set("HAL_S32", True) # bool
+    print("S32 fail")
+    try_set("HAL_S32", 0x80000000) # INT32_MAX + 1
+    try_set("HAL_S32", -0x80000001) # INT32_MIN - 1
+    try_set("HAL_S32", 1.98225e50) # Overflow float
+    try_set("HAL_S32", "foo") # TypeError
+    try_set("HAL_S32", None) # TypeError
+
+    print("U32 pass")
+    try_set("HAL_U32", 0)
+    try_set("HAL_U32", 1)
+    try_set("HAL_U32", 0xffffffff) # UINT32_MAX
+    try_set("HAL_U32", 1e5) # float
+    try_set("HAL_U32", 99.99) # float, int part
+    try_set("HAL_U32", True) # bool
+    print("U32 fail")
+    try_set("HAL_U32", -1) # Negative
+    try_set("HAL_U32", 1 <<32) # UINT32_MAX + 1
+    try_set("HAL_U32", 1.98225e50) # Overflow float
+    try_set("HAL_U32", "foo") # TypeError
+    try_set("HAL_U32", None) # TypeError
+
+    print("S64 pass")
+    # pass
+    try_set("HAL_S64", -1)
+    try_set("HAL_S64", 0)
+    try_set("HAL_S64", 1)
+    try_set("HAL_S64", 0x7fffffffffffffff) # INT64_MAX
+    try_set("HAL_S64", -0x8000000000000000) # INT64_MIN
+    try_set("HAL_S64", 1e15) # float, >32-bit
+    try_set("HAL_S64", 99.99) # float, int part
+    try_set("HAL_S64", True) # bool
+    print("S64 fail")
+    try_set("HAL_S64", 0x8000000000000000) # INT64_MAX + 1
+    try_set("HAL_S64", -0x8000000000000001) # INT64_MIN - 1
+    try_set("HAL_S64", "foo") # TypeError
+    try_set("HAL_S64", None) # TypeError
+
+    print("U64 pass")
+    try_set("HAL_U64", 0)
+    try_set("HAL_U64", 1)
+    try_set("HAL_U64", 0xffffffffffffffff) # UINT64_MAX
+    try_set("HAL_U64", 1e15) # float, >32-bit
+    try_set("HAL_U64", 99.99) # float, int part
+    try_set("HAL_U64", True) # bool
+    print("U64 fail")
+    try_set("HAL_U64", -1) # Negative
+    try_set("HAL_U64", 1 <<64) # UINT64_MAX + 1
+    try_set("HAL_U64", "foo") # TypeError
+    try_set("HAL_U64", None) # TypeError
+
+    print("FLOAT pass")
+    try_set("HAL_FLOAT", 0)
+    try_set("HAL_FLOAT", 0.0)
+    try_set("HAL_FLOAT", -1)
+    try_set("HAL_FLOAT", -1.0)
+    try_set("HAL_FLOAT", 1)
+    try_set("HAL_FLOAT", 1.0)
+    try_set("HAL_FLOAT", 1 <<1023) # large int under largest float
+    print("FLOAT fail")
+    try_set("HAL_FLOAT", 1 <<1024) # int larger than largest float
+    try_set("HAL_FLOAT", "foo") # TypeError
+    try_set("HAL_FLOAT", None) # TypeError
+
+    ########## Check pin and param attributes and hal.component.getitem() accessor
+    print("Validate pins")
+    def pin_validate(mode, i, t, d):
+        print("pincheck {} {} {} {} {}".format(
+            mode, i.get_name(), i.is_pin(), i.get_type() == t, i.get_dir() == d))
+
+    for pin_name in sorted(pins.keys()):
+        pin_type = getattr(hal, pin_name)
+
+        # Check pin object directly
+        pin_validate('direct', pins[pin_name], pin_type, hal.HAL_OUT)
+
+        # Check getitem()
+        pin = h.getitem(pin_name)
+        pin_validate('getitem', pin, pin_type, hal.HAL_OUT)
+
+    # Test getitem() failure
+    try:
+        pin = h.getitem("not-found")
+        print("{} {} {}".format("getitem", "not-found", "ok"))
+    except:
+        print("{} {} {}".format("getitem", "not-found", "fail"))
+
+    # Test params and getitem(param)
+    pin_validate('direct', param, hal.HAL_BIT, hal.HAL_RW)
+    param = h.getitem("param")
+    pin_validate('getitem', param, hal.HAL_BIT, hal.HAL_RW)
+
+    ########## Check pin set(), get(), get_name() methods
+    print("Validate set/get")
     def try_set_pin(p, v):
         try:
             p.set(v)
@@ -29,64 +135,8 @@ try:
         except OverflowError as e:
             print("setpin {} {} {}".format(p.get_name(), v, "OverflowError: %s" % e))
 
-    try_set("s", -1)
-    try_set("s", 0)
-    try_set("s", 1)
-    try_set("s", 0x7fffffff)
-    try_set("s", -0x80000000)
-
-    print("part 2")
-    try_set("u", 0)
-    try_set("u", 1)
-    try_set("u", 0xffffffff)
-
-    print("part 3")
-    try_set("f", 0)
-    try_set("f", 0.0)
-    try_set("f", -1)
-    try_set("f", -1.0)
-    try_set("f", 1)
-    try_set("f", 1.0)
-
-    print("part 4")
-    try_set("f", 1 <<1023)
-
-    print("part 5")
-    try_set("s", 0x80000000)
-    try_set("s", -0x80000001)
-
-    print("part 6")
-    try_set("u", -1)
-    try_set("u", 1 <<32)
-
-    print("part 7")
-    try_set("f", 1 <<1024)
-
-    pin = h.getitem("s")
-
-    def pin_validate(i, t, d):
-        print("pincheck {} {} {} {}".format(
-            i.get_name(), i.is_pin(), i.get_type() == t, i.get_dir() == d))
-
-    pin_validate(ps, hal.HAL_S32, hal.HAL_OUT)
-    pin_validate(pu, hal.HAL_U32, hal.HAL_OUT)
-    pin_validate(pf, hal.HAL_FLOAT, hal.HAL_OUT)
-
-    pin = h.getitem("s")
-
-    pin_validate(pin, hal.HAL_S32, hal.HAL_OUT)
-    try:
-        pin = h.getitem("not-found")
-        print("{} {} {}".format("getitem", "not-found", "ok"))
-    except:
-        print("{} {} {}".format("getitem", "not-found", "fail"))
-
-    pin_validate(param, hal.HAL_BIT, hal.HAL_RW)
-    param = h.getitem("param")
-    pin_validate(param, hal.HAL_BIT, hal.HAL_RW)
-
-    try_set_pin(pu, 0)
-    try_set_pin(pu, -1)
+    try_set_pin(pins["HAL_U32"], 0)
+    try_set_pin(pins["HAL_U32"], -1)
 except:
     import traceback
     print("Exception: {}".format(traceback.format_exc()))


### PR DESCRIPTION
64-bit (signed and unsigned) int pins can now be set and read from
Python.

Problems with 32/64-bit architecture differences turned out to be easy
and logical to resolve using `hal_{s,u}64_t` types rather than
`{un,}signed long long int`.  For consistency, other functions are
also converted to using `hal_*_t` types.

Where possible, Python is allowed to generate its own Exception
types and messages for conversion failures.  This can be more
informative in some cases.

Many extra test cases are added.