### PR TITLE
2020 08 27 compiler warnings

### DIFF
--- a/scripts/containers/buildsystem/debian/Dockerfile
+++ b/scripts/containers/buildsystem/debian/Dockerfile
@@ -199,16 +199,6 @@ RUN cd /tmp &&                                                                \
         "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" \
                   ./debian/control
 
-# This on Debian 9 Stretch, HOST_ARCHITECTURE i386 actually abuses the fact
-# that the i686-linux-gnu-gcc does not exists (the $CC is set to 'gcc -m32'),
-# so the comparison will fail and '-Werror' will be exported - what is the
-# end result we want on Stretch anyway
-RUN if ! [[ $(echo -e "$($(dpkg-architecture -a${HOST_ARCHITECTURE}     \
-                           -qDEB_HOST_GNU_TYPE)-gcc -dumpversion)\n8" | \
-            sort -V | head -n1) == "8" ]];                              \
-    then                                                                \
-        printf "%b"                                                     \
-               "#!/bin/bash\n"                                          \
-               "export DPKG_CFLAGS=\"${DPKG_CFLAGS} -Werror\"\n"        \
-               > /opt/environment/dpkg_flags.sh;                        \
-    fi
+# Package builds fail on warnings
+RUN echo -e "#!/bin/bash\nexport DPKG_CFLAGS+=' -Werror'\n"        \
+        > /opt/environment/dpkg_flags.sh

--- a/src/hal/cython/Submakefile
+++ b/src/hal/cython/Submakefile
@@ -90,7 +90,7 @@ TARGETS += ../lib/python/machinekit/shmcommon.so
 
 $(HALNGDIR)/machinekit/%.c: $(addprefix $(HALNGDIR)/machinekit/, %.pyx %.pxd)
 	$(ECHO) Cython compiling $<
-	$(Q)$(CYTHON) -o $@ $<
+	$(Q)$(CYTHON) -I $(HALNGDIR)/machinekit -o $@ $<
 
 clean: cython-clean
 cython-clean:

--- a/src/hal/cython/machinekit/compat.pxd
+++ b/src/hal/cython/machinekit/compat.pxd
@@ -1,4 +1,5 @@
 # vim: sts=4 sw=4 et
+# cython: language_level=3
 
 cdef extern from "rtapi_bitops.h":
     int RTAPI_BIT(int b)

--- a/src/hal/cython/machinekit/compat.pyx
+++ b/src/hal/cython/machinekit/compat.pyx
@@ -1,6 +1,5 @@
 # rtapi_compat.c  python bindings
 
-from .compat cimport *
 from os import strerror
 
 

--- a/src/hal/cython/machinekit/hal.pxd
+++ b/src/hal/cython/machinekit/hal.pxd
@@ -1,4 +1,5 @@
 # vim: sts=4 sw=4 et
+# cython: language_level=3
 cimport libcpp
 cimport hal_const
 from libc.stdint cimport uint64_t, int64_t

--- a/src/hal/cython/machinekit/hal.pyx
+++ b/src/hal/cython/machinekit/hal.pyx
@@ -10,12 +10,9 @@
 cimport cython
 cimport hal_const
 cimport ring_const
-from .hal cimport *
-from .rtapi cimport *
-from .hal_priv cimport *
-from .hal_rcomp cimport *
-from .hal_ring cimport *
-from .hal_objectops cimport *
+from hal cimport hal_init, hal_exit, hal_ready
+from rtapi cimport rtapi_mutex_get, rtapi_mutex_give
+from hal_objectops cimport foreach_args_t
 
 from os import strerror,getpid
 

--- a/src/hal/cython/machinekit/hal.pyx
+++ b/src/hal/cython/machinekit/hal.pyx
@@ -113,7 +113,7 @@ cdef hal_required():
     if not _comps:
         # dummy comp for connecting to HAL
         p = "machinekit::hal%d" % getpid()
-        id = hal_init(p)
+        id = hal_init(p.encode())
         if hal_data == NULL:
             raise RuntimeError("cant connect to HAL - realtime not running?")
         hal_ready(id)

--- a/src/hal/cython/machinekit/hal_component.pyx
+++ b/src/hal/cython/machinekit/hal_component.pyx
@@ -1,4 +1,11 @@
-from .hal_util cimport pypin_value
+from hal_util cimport pypin_value
+from hal_rcomp cimport (
+    hal_compiled_comp_t, hal_ccomp_free, hal_bind, hal_unbind,
+    hal_acquire, hal_release, halg_compile_comp, hal_ccomp_match,
+    hal_ccomp_report,
+    )
+from hal_objectops cimport hal_pin_t
+from hal_priv cimport halg_xinitf
 
 class ComponentExit(Exception):
     pass

--- a/src/hal/cython/machinekit/hal_data.pyx
+++ b/src/hal/cython/machinekit/hal_data.pyx
@@ -2,6 +2,10 @@
 # and the HAL heap
 
 from libc.stdint cimport uintptr_t
+from rtapi cimport (
+     rtapi_heap_stat, rtapi_heap_status,
+     rtapi_heap_setflags, rtapi_heap_walk_freelist,
+     )
 
 cdef class HALData:
     def __cinit__(self):

--- a/src/hal/cython/machinekit/hal_group.pxd
+++ b/src/hal/cython/machinekit/hal_group.pxd
@@ -1,5 +1,5 @@
-from .hal_priv cimport hal_shmem_base, hal_data_u, hal_data, hal_sig_t,halhdr_t
-from .rtapi cimport rtapi_atomic_type
+from hal_priv cimport hal_shmem_base, hal_data_u, hal_data, hal_sig_t,halhdr_t
+from rtapi cimport rtapi_atomic_type
 from libc.stdint cimport uint8_t
 
 cdef extern from "hal_group.h" :

--- a/src/hal/cython/machinekit/hal_group.pyx
+++ b/src/hal/cython/machinekit/hal_group.pyx
@@ -129,7 +129,9 @@ cdef class Member(HALObject):
         def __get__(self): return self._o.member.eps_index
         def __set__(self, int eps):
             if (eps < 0) or (eps > MAX_EPSILON-1):
-                raise InternalError("member %s : epsilon index out of range" % (self._name(), eps))
+                raise InternalError(
+		    "member %s : epsilon index %s out of range" %
+		        (self._name(), eps))
             self._o.member.eps_index = eps
 
     property userarg1:

--- a/src/hal/cython/machinekit/hal_group.pyx
+++ b/src/hal/cython/machinekit/hal_group.pyx
@@ -1,7 +1,10 @@
-from .hal_util cimport shmptr #hal2py, py2hal, shmptr, valid_dir, valid_type
-from .hal_priv cimport MAX_EPSILON, hal_data
-from .hal_group cimport *
-from .rtapi cimport  RTAPI_BIT_TEST
+from hal_util cimport shmptr #hal2py, py2hal, shmptr, valid_dir, valid_type
+from hal_priv cimport MAX_EPSILON, hal_data
+from hal_group cimport (
+    hal_compiled_group_t, hal_group_t, halg_group_new, hal_cgroup_match,
+    hal_cgroup_free, halpr_group_compile, halg_member_new, halg_member_delete,
+    )
+from rtapi cimport  RTAPI_BIT_TEST
 
 
 cdef class Group(HALObject):

--- a/src/hal/cython/machinekit/hal_inst.pyx
+++ b/src/hal/cython/machinekit/hal_inst.pyx
@@ -1,4 +1,6 @@
-from .hal_util cimport shmptr
+from hal_util cimport shmptr
+from hal_objectops cimport hal_comp_t
+from hal_priv cimport halg_inst_delete, halpr_find_owning_comp
 
 cdef class Instance(HALObject):
     cdef hal_comp_t *_comp # owning comp

--- a/src/hal/cython/machinekit/hal_iter.pxd
+++ b/src/hal/cython/machinekit/hal_iter.pxd
@@ -1,7 +1,4 @@
-
-from .hal_priv cimport *
-from .hal_ring cimport *
-from .hal_group cimport hal_group_t, hal_member_t
+from hal_group cimport hal_group_t, hal_member_t
 
 cdef extern from "hal_iter.h":
     ctypedef int (*hal_comp_callback_t)  (hal_comp_t *comp,  void *arg)

--- a/src/hal/cython/machinekit/hal_net.pyx
+++ b/src/hal/cython/machinekit/hal_net.pyx
@@ -1,7 +1,10 @@
 # net - link signal and pins by name
 import sys
 
-from .hal_const cimport HAL_BIT, HAL_FLOAT,HAL_S32,HAL_U32,HAL_S64,HAL_U64, HAL_TYPE_UNSPECIFIED, HAL_IN, HAL_OUT, HAL_IO
+from hal_const cimport (
+    HAL_BIT, HAL_FLOAT,HAL_S32,HAL_U32,HAL_S64,HAL_U64,
+    HAL_TYPE_UNSPECIFIED, HAL_IN, HAL_OUT, HAL_IO,
+    )
 
 cdef _dirdict =  { HAL_IN : "HAL_IN",
                    HAL_OUT : "HAL_OUT",

--- a/src/hal/cython/machinekit/hal_object.pyx
+++ b/src/hal/cython/machinekit/hal_object.pyx
@@ -1,3 +1,10 @@
+from hal_objectops cimport (
+    hal_object_ptr, halg_foreach, foreach_args_t, halg_find_object_by_name,
+    hh_get_name, hh_get_id, hh_get_owner_id, hh_get_object_type, hh_get_refcnt,
+    hh_incr_refcnt, hh_decr_refcnt,
+    hh_valid, hal_object_typestr, hh_snprintf,
+    )
+
 # generic finders: find names, count of a given type of object
 cdef int _append_name_cb(hal_object_ptr o,  foreach_args_t *args):
     arg =  <object>args.user_ptr1

--- a/src/hal/cython/machinekit/hal_objectops.pxd
+++ b/src/hal/cython/machinekit/hal_objectops.pxd
@@ -1,6 +1,10 @@
-from .hal_priv cimport *
-from .hal_group cimport *
-from .hal_ring cimport *
+from hal_priv cimport (
+    halhdr_t, hal_inst_t, hal_comp_t,
+    hal_funct_t, hal_thread_t, hal_vtable_t,
+    hal_pin_t, hal_param_t, hal_sig_t,
+    )
+from hal_group cimport hal_group_t, hal_member_t
+from hal_ring cimport hal_ring_t
 from cpython.bool  cimport bool
 from libc.stdint cimport uint8_t,uint32_t
 

--- a/src/hal/cython/machinekit/hal_pin.pyx
+++ b/src/hal/cython/machinekit/hal_pin.pyx
@@ -39,7 +39,7 @@ cdef class _Pin(HALObject):
 
                 if (eps < 0) or (eps > MAX_EPSILON-1):
                     raise RuntimeError("pin %s : epsilon"
-                                       " index out of range" % (name, eps))
+                                       " index %s out of range" % (name, eps))
 
                 c_bytes = name.encode()
                 c_name = c_bytes
@@ -79,7 +79,7 @@ cdef class _Pin(HALObject):
         def __get__(self): return self._o.pin.eps_index
         def __set__(self, int eps):
             if (eps < 0) or (eps > MAX_EPSILON-1):
-                raise RuntimeError("pin %s : epsilon index out of range" %
+                raise RuntimeError("pin %s : epsilon index %s out of range" %
                                    (hh_get_name(&self._o.pin.hdr), eps))
             self._o.pin.eps_index = eps
 

--- a/src/hal/cython/machinekit/hal_pin.pyx
+++ b/src/hal/cython/machinekit/hal_pin.pyx
@@ -1,5 +1,8 @@
-from .hal_priv cimport MAX_EPSILON, hal_data_u,pin_is_linked, signal_of, hals_type, hals_pindir
-from .hal_util cimport shmptr, py2hal,hal2py
+from hal_priv cimport (
+    MAX_EPSILON, hal_data_u,pin_is_linked, signal_of, hals_type,
+    hals_pindir, halg_pin_newf, _halerrno,
+    )
+from hal_util cimport shmptr, py2hal,hal2py
 
 
 def describe_hal_type(haltype):

--- a/src/hal/cython/machinekit/hal_priv.pxd
+++ b/src/hal/cython/machinekit/hal_priv.pxd
@@ -1,6 +1,9 @@
 # hal_priv.h declarations
 
-from .hal cimport *
+from hal cimport (
+    hal_bit_t, hal_s32_t, hal_u32_t, hal_s64_t, hal_u64_t, hal_float_t,
+    hal_constructor_t, hal_destructor_t,
+    )
 from hal_const cimport hal_type_t, hal_pin_dir_t, hal_param_dir_t
 from rtapi cimport rtapi_heap
 from cpython.bool  cimport bool

--- a/src/hal/cython/machinekit/hal_rcomp.pxd
+++ b/src/hal/cython/machinekit/hal_rcomp.pxd
@@ -1,7 +1,6 @@
 # hal_ring.h definitions
 
-from .hal cimport *
-from .hal_priv cimport *
+from hal_priv cimport hal_data_u, hal_pin_t
 
 cdef extern from "hal_rcomp.h":
     int RCOMP_ACCEPT_VALUES_ON_BIND

--- a/src/hal/cython/machinekit/hal_rcomp.pyx
+++ b/src/hal/cython/machinekit/hal_rcomp.pyx
@@ -1,7 +1,6 @@
 #
 
-from .hal cimport *
-from .hal_rcomp cimport *
+from hal_rcomp cimport RCOMP_ACCEPT_VALUES_ON_BIND
 from os import strerror
 
 

--- a/src/hal/cython/machinekit/hal_ring.pxd
+++ b/src/hal/cython/machinekit/hal_ring.pxd
@@ -1,8 +1,7 @@
 # hal_ring.h definitions
 
-from .hal cimport *
-from .hal_priv cimport halhdr_t
-from .ring cimport ringbuffer_t
+from hal_priv cimport halhdr_t
+from ring cimport ringbuffer_t
 
 cdef extern from "hal_ring.h":
     ctypedef struct hal_ring_t:

--- a/src/hal/cython/machinekit/hal_ring.pyx
+++ b/src/hal/cython/machinekit/hal_ring.pyx
@@ -8,11 +8,30 @@
 
 from libc.errno cimport EAGAIN
 from libc.string cimport memcpy
+from libc.stdint cimport uint32_t
 from buffer cimport PyBuffer_FillInfo
-from cpython.bytes cimport PyBytes_AsString, PyBytes_Size, PyBytes_FromStringAndSize
+from cpython.bytes cimport (
+    PyBytes_AsString, PyBytes_Size, PyBytes_FromStringAndSize,
+    )
 from cpython cimport bool
+from hal_objectops cimport hal_ring_t
 
-from .ring cimport *
+from ring cimport (
+    ringbuffer_t, ringsize_t, ringiter_t, ringvec_t,
+    msgbuffer_t, msg_read_abort, msg_read_flush, msg_write_flush,
+    record_write_begin, record_write_end, record_read, record_shift,
+    record_write_space, record_next_size,
+    record_iter_init, record_iter_read, record_iter_shift,
+    ring_scratchpad_size,
+    ring_use_rmutex, ring_use_wmutex,
+    stream_write_space, stream_flush, stream_read_space, stream_read_advance,
+    stream_write, stream_get_read_vector,
+    frame_readv, frame_shift, frame_write,
+    )
+from hal_ring cimport (
+    halg_ring_newf, halg_ring_attachf, halpr_find_ring_by_name,
+    halg_ring_detach,
+    )
 
 
 cdef class Ring:

--- a/src/hal/cython/machinekit/hal_signal.pyx
+++ b/src/hal/cython/machinekit/hal_signal.pyx
@@ -1,5 +1,10 @@
-from .hal_priv cimport hal_data_u, hal_valid_dir, hal_valid_type
-from .hal_util cimport hal2py, py2hal, shmptr
+from hal_priv cimport (
+    hal_data_u, hal_valid_dir, hal_valid_type, sig_value,
+    halg_foreach_pin_by_signal,
+    )
+from hal_util cimport hal2py, py2hal, shmptr
+from hal_objectops cimport hal_pin_t, hal_sig_t, hal_comp_t
+from hal_const cimport hal_type_t
 
 cdef int _pin_by_signal_cb(hal_pin_t *pin,
                            hal_sig_t *sig,

--- a/src/hal/cython/machinekit/hal_signal.pyx
+++ b/src/hal/cython/machinekit/hal_signal.pyx
@@ -172,7 +172,7 @@ cdef int _find_writer(hal_object_ptr o,  foreach_args_t *args):
     if signal_of(pin) == args.user_ptr1 and pin.dir == args.user_arg1:
         result =  <object>args.user_ptr2
         result.append(hh_get_name(o.hdr))
-        if pin.dir == HAL_OUT:
+        if int(pin.dir) == int(HAL_OUT):
             return 1  # stop iteration, there can only be one writer
     return 0 # continue
 

--- a/src/hal/cython/machinekit/hal_util.pxd
+++ b/src/hal/cython/machinekit/hal_util.pxd
@@ -4,17 +4,17 @@ from cpython.int   cimport PyInt_Check
 from cpython.float cimport PyFloat_Check
 from cpython.bool  cimport bool
 
-from .hal_priv     cimport hal_shmem_base, hal_data_u, hal_pin_t, hal_sig_t, hal_data
-from .hal_priv     cimport pin_type, pin_value, pin_is_linked
+from hal_priv     cimport hal_shmem_base, hal_data_u, hal_pin_t, hal_sig_t, hal_data
+from hal_priv     cimport pin_type, pin_value, pin_is_linked
 
-from .hal_priv     cimport set_bit_value, set_s32_value, set_u32_value, set_float_value
-from .hal_priv     cimport set_s64_value, set_u64_value
-from .hal_priv     cimport get_bit_value, get_s32_value, get_u32_value, get_float_value
-from .hal_priv     cimport get_s64_value, get_u64_value
+from hal_priv     cimport set_bit_value, set_s32_value, set_u32_value, set_float_value
+from hal_priv     cimport set_s64_value, set_u64_value
+from hal_priv     cimport get_bit_value, get_s32_value, get_u32_value, get_float_value
+from hal_priv     cimport get_s64_value, get_u64_value
 
-from .hal_const    cimport HAL_BIT, HAL_FLOAT,HAL_S32,HAL_U32, HAL_S64,HAL_U64,HAL_TYPE_UNSPECIFIED
-from .hal_const    cimport HAL_IN, HAL_OUT, HAL_IO
-from .rtapi cimport rtapi_mutex_get,rtapi_mutex_give
+from hal_const    cimport HAL_BIT, HAL_FLOAT,HAL_S32,HAL_U32, HAL_S64,HAL_U64,HAL_TYPE_UNSPECIFIED
+from hal_const    cimport HAL_IN, HAL_OUT, HAL_IO
+from rtapi cimport rtapi_mutex_get,rtapi_mutex_give
 import sys
 
 cdef inline void *shmptr(int offset):

--- a/src/hal/cython/machinekit/nanopb.pyx
+++ b/src/hal/cython/machinekit/nanopb.pyx
@@ -1,5 +1,3 @@
-from .nanopb  cimport *
-from .msginfo cimport *
 from libc.stdlib cimport malloc, free
 from libc.string cimport memset
 from buffer cimport PyBuffer_FillInfo

--- a/src/hal/cython/machinekit/ring.pxd
+++ b/src/hal/cython/machinekit/ring.pxd
@@ -2,7 +2,7 @@
 
 from libc.stdint cimport uint64_t, uint8_t, uint32_t, int32_t
 from libc.stddef cimport size_t
-from .rtapi cimport rtapi_atomic_type
+from rtapi cimport rtapi_atomic_type
 
 cdef extern from "ring.h":
     int RINGTYPE_RECORD

--- a/src/hal/cython/machinekit/rtapi.pxd
+++ b/src/hal/cython/machinekit/rtapi.pxd
@@ -1,4 +1,5 @@
 # vim: sts=4 sw=4 et
+# cython: language_level=3
 from libc.stddef cimport size_t
 
 cdef extern from "stdarg.h":

--- a/src/hal/cython/machinekit/rtapi.pyx
+++ b/src/hal/cython/machinekit/rtapi.pyx
@@ -10,13 +10,7 @@ from .rtapi_app cimport *
 from os import strerror, getpid
 from libc.stdlib cimport malloc, free
 from cpython.bytes cimport PyBytes_AsString
-
-
-# the PyBuffer_FillInfo declaration is broken in cython 0.19
-# from cpython.buffer cimport PyBuffer_FillInfo
-# use a temporary replacement
-# XXX make this conditional on cython version
-from buffer cimport PyBuffer_FillInfo
+from cpython.buffer cimport PyBuffer_FillInfo
 
 _HAL_KEY                   = HAL_KEY
 _RTAPI_KEY                 = RTAPI_KEY

--- a/src/hal/cython/machinekit/rtapi.pyx
+++ b/src/hal/cython/machinekit/rtapi.pyx
@@ -4,13 +4,14 @@
 # RT logger
 # rtapi_app command interface
 
-from .rtapi cimport *
-from .global_data cimport *
-from .rtapi_app cimport *
 from os import strerror, getpid
 from libc.stdlib cimport malloc, free
 from cpython.bytes cimport PyBytes_AsString
 from cpython.buffer cimport PyBuffer_FillInfo
+from rtapi_app cimport (
+    rtapi_connect, rtapi_newthread, rtapi_delthread,
+    rtapi_loadrt, rtapi_unloadrt, rtapi_newinst, rtapi_delinst, rtapi_cleanup
+    )
 
 _HAL_KEY                   = HAL_KEY
 _RTAPI_KEY                 = RTAPI_KEY

--- a/src/hal/cython/machinekit/rtapi_app.pyx
+++ b/src/hal/cython/machinekit/rtapi_app.pyx
@@ -1,6 +1,3 @@
-from .rtapi_app cimport *
-
-
 
 def connect(char *uuid, instance=0, uri=None):
     r = rtapi_connect(instance, uri, uuid)

--- a/src/hal/cython/machinekit/shmcommon.pxd
+++ b/src/hal/cython/machinekit/shmcommon.pxd
@@ -1,4 +1,5 @@
 # vim: sts=4 sw=4 et
+# cython: language_level=3
 
 
 cdef extern from "shmdrv.h":

--- a/src/hal/cython/machinekit/shmcommon.pyx
+++ b/src/hal/cython/machinekit/shmcommon.pyx
@@ -1,6 +1,3 @@
-from .shmcommon cimport *
-from .global_data cimport *
-#from os import strerror
 
 def shmdrv_loaded():
     return c_shmdrv_loaded != 0

--- a/src/hal/cython/machinekit/test.pyx
+++ b/src/hal/cython/machinekit/test.pyx
@@ -2,14 +2,6 @@
 cimport cython
 cimport hal_const
 cimport ring_const
-from .hal cimport *
-from .rtapi cimport *
-#from .hal_object cimport *
-from .hal_priv cimport *
-from .hal_rcomp cimport *
-from .hal_ring cimport *
-from .hal_objectops cimport *
-from cpython.bool cimport *
 from os import strerror,getpid
 
 

--- a/src/hal/user_comps/mb2hal/mb2hal_hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_hal.c
@@ -19,7 +19,7 @@ retCode create_HAL_pins()
 retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
 {
     char *fnct_name = "create_each_mb_tx_hal_pins";
-    char hal_pin_name[HAL_NAME_LEN + 1];
+    char hal_pin_name[HAL_NAME_LEN];
     int pin_counter;
 
     if (mb_tx == NULL) {
@@ -35,7 +35,11 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
         return retERR;
     }
     memset(mb_tx->num_errors, 0, sizeof(hal_u32_t *));
-    snprintf(hal_pin_name, HAL_NAME_LEN, "%s.%s.num_errors", gbl.hal_mod_name, mb_tx->hal_tx_name);
+    if (snprintf(hal_pin_name, HAL_NAME_LEN-1,
+                 "%s.%s.num_errors", gbl.hal_mod_name, mb_tx->hal_tx_name) < 0) {
+        ERR(gbl.init_dbg, "num_errors pin name too long");
+        return retERR;
+    }
     if (0 != hal_pin_u32_newf(HAL_OUT, mb_tx->num_errors, gbl.hal_mod_id, "%s", hal_pin_name)) {
         ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_u32_newf failed", mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
         return retERR;
@@ -85,9 +89,17 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
 
     for (pin_counter = 0; pin_counter < mb_tx->mb_tx_nelem; pin_counter++) {
         if(mb_tx->mb_tx_names){
-            snprintf(hal_pin_name, HAL_NAME_LEN, "%s.%s.%s", gbl.hal_mod_name, mb_tx->hal_tx_name, mb_tx->mb_tx_names[pin_counter]);
+          if(snprintf(hal_pin_name, HAL_NAME_LEN-1,
+                      "%s.%s.%s", gbl.hal_mod_name, mb_tx->hal_tx_name, mb_tx->mb_tx_names[pin_counter]) < 0) {
+            ERR(gbl.init_dbg, "counter pin name too long");
+            return retERR;
+          }
         }else{
-            snprintf(hal_pin_name, HAL_NAME_LEN, "%s.%s.%02d", gbl.hal_mod_name, mb_tx->hal_tx_name, pin_counter);
+          if(snprintf(hal_pin_name, HAL_NAME_LEN-1,
+                      "%s.%s.%02d", gbl.hal_mod_name, mb_tx->hal_tx_name, pin_counter) < 0) {
+            ERR(gbl.init_dbg, "counter pin name too long");
+            return retERR;
+          }
         }
         DBG(gbl.init_dbg, "mb_tx_num [%d] pin_name [%s]", mb_tx->mb_tx_num, hal_pin_name);
 

--- a/src/hal/user_comps/xhc-hb04.cc
+++ b/src/hal/user_comps/xhc-hb04.cc
@@ -698,7 +698,11 @@ int main (int argc,char **argv)
 			perror("libusb_init");
 			return 1;
 		}
-		libusb_set_debug(ctx, 3);
+#if LIBUSB_API_VERSION >= 0x01000106
+		libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, 3);
+#else
+		libusb_set_debug(ctx, 3);  // Deprecated in libusb 1.0.22
+#endif
 
 		printf("%s: waiting for XHC-HB04 device\n",modname);
 		*(xhc.hal->connected) = 0;

--- a/src/hal/user_comps/xhc-whb04b-6/usb.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/usb.cc
@@ -730,7 +730,11 @@ bool Usb::init()
 
     libusb_log_level logLevel = LIBUSB_LOG_LEVEL_INFO;
     //logLevel = LIBUSB_LOG_LEVEL_DEBUG;
+#if LIBUSB_API_VERSION >= 0x01000106
+    libusb_set_option(context, LIBUSB_OPTION_LOG_LEVEL, logLevel);
+#else
     libusb_set_debug(context, logLevel);
+#endif
 
     std::ios init(NULL);
     init.copyfmt(*verboseInitOut);

--- a/src/hal/utils/Submakefile
+++ b/src/hal/utils/Submakefile
@@ -63,6 +63,9 @@ HALMETERSRCS := \
 
 USERSRCS += $(HALMETERSRCS)
 
+# FIXME in Focal, gtk2 headers contain deprecated declarations
+$(call TOOBJS, $(HALMETERSRCS)): CFLAGS += -Wno-deprecated-declarations
+
 ../bin/halmeter: \
 		$(call TOOBJS, $(HALMETERSRCS)) \
 		../lib/libhal.so.0 \
@@ -81,6 +84,9 @@ HALSCOPESRCS := \
     hal/utils/miscgtk.c
 
 USERSRCS += $(HALSCOPESRCS)
+
+# FIXME in Focal, gtk2 headers contain deprecated declarations
+$(call TOOBJS, $(HALSCOPESRCS)): CFLAGS += -Wno-deprecated-declarations
 
 ../bin/halscope: $(call TOOBJS, $(HALSCOPESRCS)) \
 		../lib/libhal.so.0 \

--- a/src/hal/utils/halcmd.c
+++ b/src/hal/utils/halcmd.c
@@ -908,11 +908,9 @@ static int replace_vars(char *source_str, char *dest_str, int max_chars, char **
 		}
 		if (replacement==NULL) {
                     *detail = info;
-// Compiler warnings
-// Copying a buffer plus extra formatting to a buffer of same size
-// and restricting copy size to buffer size, will always raise
-// a warning re possible truncation
-                    snprintf(info, sizeof(info), "[%s]%s", sec, var);
+                    if (snprintf(info, sizeof(info)-1, "[%s]%s", sec, var) < 0) {
+                      return -7;                 // var name too long
+                    }
 		    return -5;
                 }
 		if (strlimcpy(&dp, replacement, strlen(replacement), &buf_space) < 0)

--- a/src/inifile/inivar.cc
+++ b/src/inifile/inivar.cc
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
 		    "%s: ini file not specified after -ini\n", argv[0]);
 		exit(1);
 	    } else {
-		strncpy(path, argv[t + 1], LINELEN);
+		strncpy(path, argv[t + 1], LINELEN-1);
 		t++;		/* step over following arg */
 	    }
 	} else if (!strcmp(argv[t], "-var")) {
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
 		    "%s: variable name not specified after -var\n", argv[0]);
 		exit(1);
 	    } else {
-		strncpy(_variable, argv[t + 1], LINELEN);
+		strncpy(_variable, argv[t + 1], LINELEN-1);
 		variable = _variable;
 		t++;		/* step over following arg */
 	    }
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
 		    "%s: section name not specified after -sec\n", argv[0]);
 		exit(1);
 	    } else {
-		strncpy(_section, argv[t + 1], LINELEN);
+		strncpy(_section, argv[t + 1], LINELEN-1);
 		section = _section;
 		t++;		/* step over following arg */
 	    }

--- a/src/machinetalk/lib/mk_service.cc
+++ b/src/machinetalk/lib/mk_service.cc
@@ -122,7 +122,7 @@ int mk_bindsocket(mk_netopts_t *n, mk_socket_t *s)
 {
     argvec_t ifs;
     int retval = 0;
-    char buf[PATH_MAX];
+    char buf[PATH_MAX-4];  // Leave space for "dsn="
     string delims("\t ");
 
     assert(n != NULL);

--- a/src/machinetalk/lib/syslog_async.c
+++ b/src/machinetalk/lib/syslog_async.c
@@ -276,7 +276,8 @@ void log_write_async(void)
 	  memmove(entries->payload, start, entries->length);
 	  entries->payload[entries->length - 1] = '\r';
 	  entries->payload[entries->length] = '\n';
-	  write(fd, entries->payload, entries->length + 1);
+          if (write(fd, entries->payload, entries->length + 1))
+            do {} while (0); // Silence -Werror=unused-result
 	  close(fd);
 	}
 

--- a/src/rtapi/rtapi_app_module.hh
+++ b/src/rtapi/rtapi_app_module.hh
@@ -65,8 +65,8 @@ int Module::load(string module)
     // First look in `$MK_MODULE_DIR` if `module` contains no `/` chars
     if (getenv("MK_MODULE_DIR") != NULL && is_rpath) {
         // If $MK_MODULE_DIR/module.so exists, load it (or fail)
-        strncpy(module_path, getenv("MK_MODULE_DIR"), PATH_MAX);
-        strncat(module_path, ("/" + dlpath).c_str(), PATH_MAX);
+        strncpy(module_path, getenv("MK_MODULE_DIR"), PATH_MAX-1);
+        strncat(module_path, ("/" + dlpath).c_str(), PATH_MAX-1);
         if (stat(module_path, &st) == 0) {
             handle = dlopen(module_path, RTLD_GLOBAL|RTLD_NOW);
             if (!handle) {
@@ -97,7 +97,7 @@ string Module::path()
         rtapi_print_msg(RTAPI_MSG_ERR, "dlinfo(%s):  %s", path, dlerror());
         return NULL;
     }
-    strncat(path, ("/" + name + ".so").c_str(), PATH_MAX);
+    strncat(path, ("/" + name + ".so").c_str(), PATH_MAX-1);
 
     return string(path);
 }

--- a/src/rtapi/rtapi_msgd.cc
+++ b/src/rtapi/rtapi_msgd.cc
@@ -176,7 +176,10 @@ static int port = -1; // defaults to ephemeral port
 
 static ringbuffer_t rtapi_msg_buffer;   // ring access strcuture for messages
 static const char *progname;
-static char proctitle[20];
+// Hack:  Pick constant length 10, enough space for "rtapi:xxx", to
+// silence compiler warnings
+#define PROC_TITLE_LEN 10
+static char proctitle[PROC_TITLE_LEN];
 static int exit_code  = 0;
 static const char *origins[] = { "kernel", "rt", "user" };
 
@@ -688,7 +691,6 @@ int main(int argc, char **argv)
     int c, i, retval;
     int option = LOG_NDELAY;
     pid_t pid, sid;
-    size_t argv0_len, procname_len, max_procname_len;
 
     inifile = getenv("MACHINEKIT_INI");
 
@@ -820,7 +822,7 @@ int main(int argc, char **argv)
         }
     }
 
-    snprintf(proctitle, sizeof(proctitle), "msgd:%d",rtapi_instance);
+    snprintf(proctitle, PROC_TITLE_LEN, "msgd:%d",rtapi_instance);
     backtrace_init(proctitle);
 
     openlog_async(proctitle, option , SYSLOG_FACILITY);
@@ -828,15 +830,9 @@ int main(int argc, char **argv)
     // max out async syslog buffers for slow system in debug mode
     tunelog_async(99,10);
 
-    // set new process name
-    argv0_len = strlen(argv[0]);
-    procname_len = strlen(proctitle);
-    max_procname_len = (argv0_len > procname_len) ? (procname_len) : (argv0_len);
-    // Compiler warnings.
-    // `specified bound depends on the length of the source argument [-Wstringop-overflow=]`
-    // which isn't actually correct since it is limited to size of smallest string by preceding lines.
-    strncpy(argv[0], proctitle, max_procname_len);
-    memset(&argv[0][max_procname_len], '\0', argv0_len - max_procname_len);
+    // Hack:  Pick constant 10, enough space for "rtapi:xxx", to
+    // silence compiler warnings
+    strncpy(argv[0], proctitle, PROC_TITLE_LEN);
 
     for (i = 1; i < argc; i++)
 	memset(argv[i], '\0', strlen(argv[i]));

--- a/tests/hm2-idrom/skip
+++ b/tests/hm2-idrom/skip
@@ -1,7 +1,0 @@
-#!/bin/bash
-#                                                       -*-shell-script-*-
-
-# Skip the hm2-idrom test if not running kernel threads and the
-# hostmot2.so module doesn't exist for this flavor
-
-test -f $HAL_HOME/rtlib/modules/hostmot2.so

--- a/tests/hm2-idrom/test.sh
+++ b/tests/hm2-idrom/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -xe
 
 
 Error[0]="hm2/hm2_test.0: invalid cookie"
@@ -20,7 +20,7 @@ Error[14]="hm2/hm2_test\.0: IDROM IOPorts is 0 but llio num_ioport_connectors is
 
 # obtain one logfile per test, and search only that for the pattern
 
-realtime stop
+realtime stop || true
 
 LOG=realtime.log
 retval=0
@@ -31,7 +31,7 @@ ls ${LOG}.* >&/dev/null && rm -f ${LOG}.*
 TEST_PATTERN=0
 while [ ! -z "${Error[$TEST_PATTERN]}" ]; do
 
-    MSGD_OPTS="--stderr" DEBUG=5 realtime start  >$LOG 2>&1
+    MSGD_OPTS="--stderr" RTAPI_APP_OPTS="-s" DEBUG=5 realtime start  >$LOG 2>&1
 
     halcmd loadrt hostmot2 >/dev/null 2>&1
     halcmd loadrt hm2_test test_pattern=$TEST_PATTERN >/dev/null 2>&1


### PR DESCRIPTION
Fix all remaining compiler warnings and re-enable `-Werror` for all distros and `gcc` versions.

A couple of warnings from `gtk2` are simply disabled for the related files; these should be fixed by replacing `gtk2` with something else entirely.

Cython warned about setting `language_level`; setting this to `3` led to a pile of Cython clean-ups.  As such, this part might be seen as a follow-up to #303.

Also, add a couple of tweaks to the `hm2-idrom` test.  The `test.sh` script doesn't exit immediately after fatal errors, certainly adding to the confusion surrounding issue #296.
