### PR TITLE
Update broken rsyslog.conf

### DIFF
--- a/src/rtapi/rsyslogd-hal.conf
+++ b/src/rtapi/rsyslogd-hal.conf
@@ -21,7 +21,11 @@
 
 # so increase the rate limits of the imux socket:
 
-$SystemLogRateLimitInterval 2
-$SystemLogRateLimitBurst 5000 
+module(
+  load="imuxsock"
+  SysSock.RateLimit.Interval="2"
+  SysSock.RateLimit.Burst="5000"
+  SysSock.Name="/dev/log"
+)
 
 local1.*   /var/log/hal.log


### PR DESCRIPTION
The `$SystemLogRateLimitInterval` and `$SystemLogRateLimitBurst`
parameters are now [obsolete legacy parameters][1].

The modern equivalents are `SysSock.RateLimit.Interval` and
`SysSock.RateLimit.Burst=`.  The latter was introduced in `rsyslog`
v. 5.7.1; the version in Stretch is 8.24.0, so this change shouldn't
break the older supported distros.

[1]: https://www.rsyslog.com/doc/v8-stable/configuration/modules/imuxsock.html#syssock-ratelimit-interval