### PR TITLE
hm2_eth: update hm2 to support multiple boards

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_7i43.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_7i43.c
@@ -223,7 +223,7 @@ int hm2_7i43_read(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
 
 
 
-int hm2_7i43_write(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
+int hm2_7i43_write(hm2_lowlevel_io_t *this, u32 addr, const void *buffer, int size) {
     int bytes_remaining = size;
     hm2_7i43_t *board = this->private;
 

--- a/src/hal/drivers/mesa-hostmot2/hm2_7i90.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_7i90.c
@@ -203,7 +203,7 @@ int hm2_7i90_read(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
 
 
 
-int hm2_7i90_write(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
+int hm2_7i90_write(hm2_lowlevel_io_t *this, u32 addr, const void *buffer, int size) {
     int bytes_remaining = size;
     hm2_7i90_t *board = this->private;
 
@@ -369,4 +369,3 @@ void rtapi_app_exit(void) {
     hal_exit(comp_id);
     LL_PRINT("driver unloaded\n");
 }
-

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -21,6 +21,7 @@
 #include "config_module.h"
 #include RTAPI_INC_SLAB_H
 #include RTAPI_INC_CTYPE_H
+#include RTAPI_INC_STRING_H
 
 #include <sys/fcntl.h>
 #include <sys/ioctl.h>
@@ -47,7 +48,38 @@
 #include "hostmot2-lowlevel.h"
 #include "hostmot2.h"
 #include "hm2_eth.h"
-#include "lbp16.h"
+
+struct kvlist {
+    struct list_head list;
+    char key[16];
+    int value;
+};
+
+static struct list_head board_num;
+static struct list_head ifnames;
+
+static int *kvlist_lookup(struct list_head *head, const char *name) {
+    struct list_head *ptr;
+    list_for_each(ptr, head) {
+        struct kvlist *ent = list_entry(ptr, struct kvlist, list);
+        if(strncmp(name, ent->key, sizeof(ent->key)) == 0) return &ent->value;
+    }
+    struct kvlist *ent = kzalloc(sizeof(struct kvlist), GFP_KERNEL);
+    strncpy(ent->key, name, sizeof(ent->key));
+    list_add(&ent->list, head);
+    return &ent->value;
+}
+
+static void kvlist_free(struct list_head *head) {
+    struct list_head *orig_head = head;
+    for(head = head->next; head != orig_head;) {
+        struct list_head *ptr = head;
+        head = head->next;
+        struct kvlist *ent = list_entry(ptr, struct kvlist, list);
+        list_del(ptr);
+        kfree(ent);
+    }
+}
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Michael Geszkiewicz");
@@ -56,8 +88,8 @@ MODULE_DESCRIPTION("Driver for HostMot2 on the 7i80 Anything I/O board from Mesa
 MODULE_SUPPORTED_DEVICE("Mesa-AnythingIO-7i80");
 #endif
 
-static char *board_ip;
-RTAPI_MP_STRING(board_ip, "ip address of ethernet board(s)");
+static char *board_ip[MAX_ETH_BOARDS];
+RTAPI_MP_ARRAY_STRING(board_ip, MAX_ETH_BOARDS, "ip address of ethernet board(s)");
 
 static char *config[MAX_ETH_BOARDS];
 RTAPI_MP_ARRAY_STRING(config, MAX_ETH_BOARDS, "config string for the AnyIO boards (see hostmot2(9) manpage)")
@@ -65,7 +97,6 @@ RTAPI_MP_ARRAY_STRING(config, MAX_ETH_BOARDS, "config string for the AnyIO board
 int debug = 0;
 RTAPI_MP_INT(debug, "Developer/debug use only!  Enable debug logging.");
 
-static hm2_eth_t boards[MAX_ETH_BOARDS];
 static int boards_count = 0;
 
 int comm_active = 0;
@@ -74,29 +105,13 @@ static int comp_id;
 
 #define UDP_PORT 27181
 #define SEND_TIMEOUT_US 10
-#define RECV_TIMEOUT_US 10
+#define RECV_TIMEOUT_US 100        // 100000 nanoseconds, which was the minimum recv timeout before anyway
 #define READ_PCK_DELAY_NS 10000
 
-static int sockfd = -1;
-static struct sockaddr_in local_addr;
-static struct sockaddr_in server_addr;
-
-static lbp16_cmd_addr read_packet;
-
-read_queue_entry_t queue_reads[MAX_ETH_READS];
-lbp16_cmd_addr queue_packets[MAX_ETH_READS];
-int queue_reads_count = 0;
-int queue_buff_size = 0;
-
-static u8 write_packet[1400];
-void *write_packet_ptr = &write_packet;
-int write_packet_size = 0;
-int read_cnt = 0;
-int write_cnt = 0;
+static hm2_eth_t boards[MAX_ETH_BOARDS];
 
 /// ethernet io functions
 
-struct arpreq req;
 static int eth_socket_send(int sockfd, const void *buffer, int len, int flags);
 static int eth_socket_recv(int sockfd, void *buffer, int len, int flags);
 
@@ -107,17 +122,29 @@ static int shell(char *command) {
     char *const argv[] = {"sh", "-c", command, NULL};
     pid_t pid;
     int res = posix_spawn(&pid, "/bin/sh", NULL, NULL, argv, environ);
-    if(res < 0) perror("posix_spawn");
+    if (res < 0) perror("posix_spawn");
     int status;
     waitpid(pid, &status, 0);
-    if(WIFEXITED(status)) return WEXITSTATUS(status);
-    else if(WIFSTOPPED(status)) return WTERMSIG(status)+128;
+    if (WIFEXITED(status)) return WEXITSTATUS(status);
+    else if (WIFSTOPPED(status)) return WTERMSIG(status)+128;
     else return status;
 }
 
-// Assume we can use iptables if this chain exists
-static bool _use_iptables() {
-    if(geteuid() != 0) return 0;
+static int eshellf(char *fmt, ...) {
+    char commandbuf[1024];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(commandbuf, sizeof(commandbuf), fmt, ap);
+    va_end(ap);
+
+    int res = shell(commandbuf);
+    if (res == EXIT_SUCCESS) return 0;
+
+    LL_PRINT("ERROR: Failed to execute '%s'\n", commandbuf);
+    return -EINVAL;
+}
+
+static bool chain_exists() {
     int result =
         shell(IPTABLES" -n -L "CHAIN" > /dev/null 2>&1");
     return result == EXIT_SUCCESS;
@@ -125,7 +152,23 @@ static bool _use_iptables() {
 
 static int iptables_state = -1;
 static bool use_iptables() {
-    if(iptables_state == -1) iptables_state = _use_iptables();
+    if (iptables_state == -1) {
+        if (geteuid() != 0) return (iptables_state = 0);
+        if (!chain_exists()) {
+            int res = shell("/sbin/iptables -N " CHAIN);
+            if (res != EXIT_SUCCESS) {
+                LL_PRINT("ERROR: Failed to create iptables chain "CHAIN);
+                return (iptables_state = 0);
+            }
+        }
+        // now add a jump to our chain at the start of the OUTPUT chain if it isn't in the chain already
+        int res = shell("/sbin/iptables -C OUTPUT -j " CHAIN " || /sbin/iptables -I OUTPUT 1 -j " CHAIN);
+        if (res != EXIT_SUCCESS) {
+            LL_PRINT("ERROR: Failed to insert rule in OUTPUT chain");
+            return (iptables_state = 0);
+        }
+        return (iptables_state = 1);
+    }
     return iptables_state;
 }
 
@@ -139,15 +182,24 @@ static char* inet_ntoa_buf(struct in_addr in, char *buf, size_t n) {
     return buf;
 }
 
-static char* fetch_ifname(struct sockaddr_in srcaddr, char *buf, size_t n) {
+static char* fetch_ifname(int sockfd, char *buf, size_t n) {
+    struct sockaddr_in srcaddr;
     struct ifaddrs *ifa, *it;
 
-    if(getifaddrs(&ifa) < 0) return NULL;
+    socklen_t addrlen = sizeof(srcaddr);
+    int res = getsockname(sockfd, &srcaddr, &addrlen);
+    if (res < 0) return NULL;
 
-    for(it=ifa; it; it=it->ifa_next) {
+    if (getifaddrs(&ifa) < 0) {
+        perror("getifaddrs");
+        return NULL;
+    }
+
+    for (it=ifa; it; it=it->ifa_next) {
         struct sockaddr_in *ifaddr = (struct sockaddr_in*)it->ifa_addr;
-        if(ifaddr->sin_family != srcaddr.sin_family) continue;
-        if(ifaddr->sin_addr.s_addr != srcaddr.sin_addr.s_addr) continue;
+        if (ifaddr == NULL) continue;
+        if (ifaddr->sin_family != srcaddr.sin_family) continue;
+        if (ifaddr->sin_addr.s_addr != srcaddr.sin_addr.s_addr) continue;
         rtapi_snprintf(buf, n, "%s", it->ifa_name);
         freeifaddrs(ifa);
         return buf;
@@ -159,8 +211,8 @@ static char* fetch_ifname(struct sockaddr_in srcaddr, char *buf, size_t n) {
 
 static char *vseprintf(char *buf, char *ebuf, const char *fmt, va_list ap) {
     int result = rtapi_vsnprintf(buf, ebuf-buf, fmt, ap);
-    if(result < 0) return ebuf;
-    else if(buf + result > ebuf) return ebuf;
+    if (result < 0) return ebuf;
+    else if (buf + result > ebuf) return ebuf;
     else return buf + result;
 }
 
@@ -181,31 +233,30 @@ static int install_iptables_rule(const char *fmt, ...) {
     ptr = vseprintf(ptr, ebuf, fmt, ap);
     va_end(ap);
 
-    if(ptr == ebuf)
+    if (ptr == ebuf)
     {
         LL_PRINT("ERROR: commandbuf too small\n");
         return -ENOSPC;
     }
 
     int res = shell(commandbuf);
-    if(res == EXIT_SUCCESS) return 0;
+    if (res == EXIT_SUCCESS) return 0;
 
     LL_PRINT("ERROR: Failed to execute '%s'\n", commandbuf);
     return -EINVAL;
 }
 
-static int install_iptables(int sockfd) {
+static int install_iptables_board(int sockfd) {
     struct sockaddr_in srcaddr, dstaddr;
     char srchost[16], dsthost[16]; // enough for 255.255.255.255\0
-    char ifbuf[64]; // more than enough for eth0
 
     socklen_t addrlen = sizeof(srcaddr);
     int res = getsockname(sockfd, &srcaddr, &addrlen);
-    if(res < 0) return -errno;
+    if (res < 0) return -errno;
 
     addrlen = sizeof(dstaddr);
     res = getpeername(sockfd, &dstaddr, &addrlen);
-    if(res < 0) return -errno;
+    if (res < 0) return -errno;
 
     res = install_iptables_rule(
         "-p udp -m udp -d %s --dport %d -s %s --sport %d -j ACCEPT",
@@ -213,74 +264,134 @@ static int install_iptables(int sockfd) {
         ntohs(dstaddr.sin_port),
         inet_ntoa_buf(srcaddr.sin_addr, srchost, sizeof(srchost)),
         ntohs(srcaddr.sin_port));
-    if(res < 0) return res;
+    return res;
+}
 
+static int install_iptables_perinterface(const char *ifbuf) {
     // without this rule, 'ping' spews a lot of messages like
     //    From 192.168.1.1 icmp_seq=5 Packet filtered
     // many times for each ping packet sent.  With this rule,
     // ping prints 'ping: sendmsg: Operation not permitted' once
     // per second.
-    res = install_iptables_rule(
+    int res = install_iptables_rule(
         "-o %s -p icmp -j DROP",
-        fetch_ifname(srcaddr, ifbuf, sizeof(ifbuf)));
-    if(res < 0) return res;
+        ifbuf);
+    if (res < 0) return res;
 
     res = install_iptables_rule(
         "-o %s -j REJECT --reject-with icmp-admin-prohibited",
         ifbuf);
-    if(res < 0) return res;
+    if (res < 0) return res;
+
+    res = eshellf("/sbin/sysctl -q net.ipv6.conf.%s.disable_ipv6=1", ifbuf);
+    if (res < 0) return res;
 
     return 0;
 }
 
-static int fetch_hwaddr(int sockfd, unsigned char buf[6]) {
+static int fetch_hwaddr(const char *board_ip, int sockfd, unsigned char buf[6]) {
     lbp16_cmd_addr packet;
     unsigned char response[6];
     LBP16_INIT_PACKET4(packet, 0x4983, 0x0002);
     int res = eth_socket_send(sockfd, &packet, sizeof(packet), 0);
-    if(res < 0) return -errno;
+    if (res < 0) return -errno;
 
     int i=0;
     do {
         res = eth_socket_recv(sockfd, &response, sizeof(response), 0);
-    } while(++i < 10 && res < 0 && errno == EAGAIN);
-    if(res < 0) return -errno;
+    } while (++i < 10 && res < 0 && errno == EAGAIN);
+    if (res < 0) return -errno;
 
     // eeprom order is backwards from arp AF_LOCAL order
-    for(i=0; i<6; i++) buf[i] = response[5-i];
+    for (i=0; i<6; i++) buf[i] = response[5-i];
 
-    LL_PRINT("Hardware address: %02x:%02x:%02x:%02x:%02x:%02x\n",
-        buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]);
+    LL_PRINT("%s: Hardware address: %02x:%02x:%02x:%02x:%02x:%02x\n",
+        board_ip, buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]);
 
     return 0;
 }
 
-static int init_net(void) {
+// return value indicates if still under the error limit ceiling or not
+// if returns false, the persistent io_error flag has been set and requires
+// operator intervention)
+static bool record_soft_error(hm2_eth_t *board) {
+    if (!board->hal) {
+        LL_PRINT("Ignoring soft error during init\n");
+        return true;   // still early in hm2_eth_probe
+    }
+
+    // From what I discern, the llio driver here can tolerate some limited packet loss (or timeouts on reads).
+    // The soft reset flag triggers later write's to do a full force write to refresh the FPGA in case
+    // its out of sync I guess.
+    board->llio.needs_soft_reset = 1;
+    *board->hal->packet_error = 1;
+
+    int32_t increment = *board->hal->packet_error_increment;
+
+    // packet_error_increment can be set by other code so sanity check it a little
+    if (increment < 1) increment = 1;
+    board->comm_error_counter += increment;
+
+    // Bound the error counter to sane values (because the error increment and decrement amounts are
+    // exposed in hal and could be tweaked by some other code)
+    if (board->comm_error_counter < 0 || board->comm_error_counter > *board->hal->packet_error_limit)
+        board->comm_error_counter = *board->hal->packet_error_limit;
+
+    *board->hal->packet_error_level = board->comm_error_counter;
+
+    if (board->comm_error_counter == *board->hal->packet_error_limit) {
+        // had enough packet errors to trip the persistent io_error state that requires user intervention
+        *board->hal->packet_error_exceeded = 1;
+        *board->llio.io_error = 1;
+        LL_PRINT("Recording soft error that tripped hard io_error. iter=%d\n", board->read_cnt);
+        return false;
+    } else {
+        // counted an error, but it hasn't reached the critical level yet.
+        //
+        // note the original code didn't reset io_error here, it only set it to true if limit was hit
+        // io_error indicates a "permanent" error that needs user intervention to fix
+        *board->hal->packet_error_exceeded = 0;
+        LL_PRINT("Recording soft error. iter=%d\n", board->read_cnt);
+        return true;
+    }
+}
+
+static void decrement_soft_error(hm2_eth_t *board) {
+    if (!board->hal) return; // still early in hm2_eth_probe
+
+    // packet_error_decrement can be set by other code so sanity check it a little
+    int32_t decrement = *board->hal->packet_error_decrement;
+    if (decrement < 1) decrement = 1;
+
+    board->comm_error_counter -= decrement;
+    if (board->comm_error_counter < 0) board->comm_error_counter = 0;
+    *board->hal->packet_error_level = board->comm_error_counter;
+    *board->hal->packet_error = 0;
+    *board->hal->packet_error_exceeded = 0;
+}
+
+static int init_board(hm2_eth_t *board, const char *board_ip) {
     int ret;
 
-    sockfd = socket(PF_INET, SOCK_DGRAM, IPPROTO_IP);
-    if (sockfd < 0) {
+    board->sockfd = socket(PF_INET, SOCK_DGRAM, IPPROTO_IP);
+    if (board->sockfd < 0) {
         LL_PRINT("ERROR: can't open socket: %s\n", strerror(errno));
         return -errno;
     }
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(LBP16_UDP_PORT);
-    server_addr.sin_addr.s_addr = inet_addr(board_ip);
+    board->server_addr.sin_family = AF_INET;
+    board->server_addr.sin_port = htons(LBP16_UDP_PORT);
+    board->server_addr.sin_addr.s_addr = inet_addr(board_ip);
 
-    local_addr.sin_family      = AF_INET;
-    local_addr.sin_addr.s_addr = INADDR_ANY;
+    board->local_addr.sin_family      = AF_INET;
+    board->local_addr.sin_addr.s_addr = INADDR_ANY;
 
-    ret = connect(sockfd, (struct sockaddr *) &server_addr, sizeof(struct sockaddr_in));
+    ret = connect(board->sockfd, (struct sockaddr *) &board->server_addr, sizeof(struct sockaddr_in));
     if (ret < 0) {
         LL_PRINT("ERROR: can't connect: %s\n", strerror(errno));
         return -errno;
     }
 
-    if(use_iptables()) {
-        LL_PRINT("Using iptables for exclusive access to network interface\n")
-        // firewall has to be open in order to successfully arp the board
-        clear_iptables();
-    } else {
+    if (!use_iptables()) {
         LL_PRINT(\
 "WARNING: Unable to restrict other access to the hm2-eth device.\n"
 "This means that other software using the same network interface can violate\n"
@@ -291,62 +402,79 @@ static int init_net(void) {
     timeout.tv_sec = 0;
     timeout.tv_usec = RECV_TIMEOUT_US;
 
-    ret = setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout, sizeof(timeout));
+    ret = setsockopt(board->sockfd, SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout, sizeof(timeout));
     if (ret < 0) {
         LL_PRINT("ERROR: can't set socket option: %s\n", strerror(errno));
         return -errno;
     }
 
     timeout.tv_usec = SEND_TIMEOUT_US;
-    setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, (char *)&timeout, sizeof(timeout));
+    setsockopt(board->sockfd, SOL_SOCKET, SO_SNDTIMEO, (char *)&timeout, sizeof(timeout));
     if (ret < 0) {
         LL_PRINT("ERROR: can't set socket option: %s\n", strerror(errno));
         return -errno;
     }
 
-    memset(&req, 0, sizeof(req));
+    // Manually create an ARP entry over to the mesa board so the IP stack doesn't need to
+    // figure that out.
+
+    memset(&board->req, 0, sizeof(board->req));
     struct sockaddr_in *sin;
 
-    sin = (struct sockaddr_in *) &req.arp_pa;
+    sin = (struct sockaddr_in *) &board->req.arp_pa;
     sin->sin_family = AF_INET;
     sin->sin_addr.s_addr = inet_addr(board_ip);
 
-    req.arp_ha.sa_family = AF_LOCAL;
-    req.arp_flags = ATF_PERM | ATF_COM;
-    ret = fetch_hwaddr( sockfd, (void*)&req.arp_ha.sa_data );
-    if(ret < 0) {
-        LL_PRINT("ERROR: Could not retrieve mac address\n");
+    board->req.arp_ha.sa_family = AF_LOCAL;
+    board->req.arp_flags = ATF_PERM | ATF_COM;
+    ret = fetch_hwaddr( board_ip, board->sockfd, (void*)&board->req.arp_ha.sa_data );
+    if (ret < 0) {
+        LL_PRINT("ERROR: %s: Could not retrieve mac address\n", board_ip);
         return ret;
     }
 
-    ret = ioctl(sockfd, SIOCSARP, &req);
-    if(ret < 0) {
-        perror("ioctl SIOCSARP");
-        req.arp_flags &= ~ATF_PERM;
+    ret = ioctl(board->sockfd, SIOCSARP, &board->req);
+    if (ret < 0) {
+        LL_PRINT("ERROR: ioctl SIOCSARP failed: %s\n", strerror(errno));
+        board->req.arp_flags &= ~ATF_PERM;
         return -errno;
     }
 
-    if(use_iptables())
+    // Setup firewall rules
+
+    if (use_iptables())
     {
-        ret = install_iptables(sockfd);
-        if(ret < 0) return ret;
+        ret = install_iptables_board(board->sockfd);
+        if (ret < 0) return ret;
     }
+
+    board->write_packet_ptr = board->write_packet;
+    board->read_packet_ptr = board->read_packet;
 
     return 0;
 }
 
-static int close_net(void) {
-    if(use_iptables()) clear_iptables();
+static int close_board(hm2_eth_t *board) {
+    int ret = 0;
+    if (board->sockfd != -1) {
+        if (use_iptables()) clear_iptables();
 
-    if(req.arp_flags & ATF_PERM) {
-        int ret = ioctl(sockfd, SIOCDARP, &req);
-        if(ret < 0) perror("ioctl SIOCDARP");
+        if (board->req.arp_flags & ATF_PERM) {
+            ret = ioctl(board->sockfd, SIOCDARP, &board->req);
+            if (ret < 0) perror("ioctl SIOCDARP");
+        }
+
+        ret = shutdown(board->sockfd, SHUT_RDWR);
+        if (ret != 0)
+            LL_PRINT("ERROR: can't shutdown socket: %s\n", strerror(errno));
+
+        ret = close(board->sockfd);
+        if (ret != 0)
+            LL_PRINT("ERROR: can't close socket: %s\n", strerror(errno));
+
+        board->sockfd = -1;
     }
-    int ret = shutdown(sockfd, SHUT_RDWR);
-    if (ret < 0)
-        LL_PRINT("ERROR: can't close socket: %s\n", strerror(errno));
-
-    return ret < 0 ? -errno : 0;
+    return ret;
 }
 
 static int eth_socket_send(int sockfd, const void *buffer, int len, int flags) {
@@ -357,82 +485,317 @@ static int eth_socket_recv(int sockfd, void *buffer, int len, int flags) {
     return recv(sockfd, buffer, len, flags);
 }
 
+static int eth_socket_recv_loop(int sockfd, void *buffer, int len, int flags, long timeout_ns) {
+    // Seems like this should be using rtapi_get_time() and not rtapi_get_clocks()
+    // since the timeout is specified in nanos.
+    // Changed it.
+    long long end = rtapi_get_time() + timeout_ns;
+    int result;
+    do {
+        result = eth_socket_recv(sockfd, buffer, len, flags);
+    } while (result < 0 && rtapi_get_time() < end);
+    return result;
+}
+
 /// hm2_eth io functions
+/// Documented to return 0 on failure.  !0 on success.
 
 static int hm2_eth_read(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
-    int send, recv, i = 0;
+    hm2_eth_t *board = this->private;
+    int send, recv, attempts = 0;
     u8 tmp_buffer[size + 4];
-    long long t1, t2;
+    long long t1, t2, before_recv_time;
+    long int deltat;
+    long long read_start_time = rtapi_get_time();
 
-    if (comm_active == 0) return 1;
-    if (size == 0) return 1;
-    read_cnt++;
+    if (comm_active == 0) return 1;    // Fake success
+    if (size == 0) return 1;           // Fake success
+
+    board->read_cnt++;
+
+    // Are we running in a realtime task context?
+    if (rtapi_task_self() >= 0) {
+        static bool printed = false;
+        if (!printed) {
+            LL_PRINT("ERROR: used llio->read in realtime task (addr=0x%04x)\n", addr);
+            LL_PRINT("This causes additional network packets which hurts performance\n");
+            printed = true;
+        }
+    }
+
+    lbp16_cmd_addr read_packet;
 
     LBP16_INIT_PACKET4(read_packet, CMD_READ_HOSTMOT2_ADDR32_INCR(size/4), addr & 0xFFFF);
 
-    send = eth_socket_send(sockfd, (void*) &read_packet, sizeof(read_packet), 0);
-    if(send < 0)
+    send = eth_socket_send(board->sockfd, (void*) &read_packet, sizeof(read_packet), 0);
+    if (send < 0) {
         LL_PRINT("ERROR: sending packet: %s\n", strerror(errno));
-    LL_PRINT_IF(debug, "read(%d) : PACKET SENT [CMD:%02X%02X | ADDR: %02X%02X | SIZE: %d]\n", read_cnt, read_packet.cmd_hi, read_packet.cmd_lo,
+        if (record_soft_error(board))
+            return -EAGAIN;
+        else
+            return 0;   // Don't bother trying to receive the answer when the request wasn't sent successfully...
+    }
+
+    LL_PRINT_IF(debug, "read(%d) : PACKET SENT [CMD:%02X%02X | ADDR: %02X%02X | SIZE: %d]\n", board->read_cnt, read_packet.cmd_hi, read_packet.cmd_lo,
       read_packet.addr_lo, read_packet.addr_hi, size);
     t1 = rtapi_get_time();
+    before_recv_time = t1;
     do {
-        rtapi_delay(READ_PCK_DELAY_NS);
-        recv = eth_socket_recv(sockfd, (void*) &tmp_buffer, size, 0);
+        errno = 0;
+
+        // This will block for up to RECV_TIMEOUT_US - which is 100,000 nanoseconds.
+        // The hard coded timeout deadline below is 200,000,000 nanoseconds or 200 milliseconds.
+        // An immense amount of time, not sure why that was picked...
+        recv = eth_socket_recv(board->sockfd, (void*) &tmp_buffer, size, 0);
+
         t2 = rtapi_get_time();
-        i++;
+
+        // Capture the max time we are ever stuck inside recv calls
+        deltat = (long int)(t2 - before_recv_time);
+        before_recv_time = t2;
+        if ((board->hal) && (*board->hal->packet_recv_tmax < deltat))
+            *board->hal->packet_recv_tmax = deltat;
+
+        attempts++;
     } while ((recv < 0) && ((t2 - t1) < 200*1000*1000));
 
+    // Capture the max recv attempts
+    if ((board->hal) && (*board->hal->packet_recv_attempts < attempts))
+        *board->hal->packet_recv_attempts = attempts;
+
     if (recv == 4) {
-        LL_PRINT_IF(debug, "read(%d) : PACKET RECV [DATA: %08X | SIZE: %d | TRIES: %d | TIME: %llu]\n", read_cnt, *tmp_buffer, recv, i, t2 - t1);
+        LL_PRINT_IF(debug, "read(%d) : PACKET RECV [DATA: %08X | SIZE: %d | TRIES: %d | TIME: %llu]\n", board->read_cnt, *tmp_buffer, recv, attempts, t2 - t1);
     } else {
-        LL_PRINT_IF(debug, "read(%d) : PACKET RECV [SIZE: %d | TRIES: %d | TIME: %llu]\n", read_cnt, recv, i, t2 - t1);
+        LL_PRINT_IF(debug, "read(%d) : PACKET RECV [SIZE: %d | TRIES: %d | TIME: %llu]\n", board->read_cnt, recv, attempts, t2 - t1);
     }
-    if (recv < 0)
-        return 0;
+
+    if (recv < 0) {
+        if (record_soft_error(board))
+            return -EAGAIN;
+        else
+            return 0;
+    }
+
     memcpy(buffer, tmp_buffer, size);
+    decrement_soft_error(board);
+
+    // Capture the max time we ever spend inside hm2_eth_read()
+    deltat = (long int) (rtapi_get_time() - read_start_time);
+    if ((board->hal) && (*board->hal->packet_read_tmax < deltat))
+        *board->hal->packet_read_tmax = deltat;
+
     return 1;  // success
 }
 
-static int hm2_eth_enqueue_read(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
-    if (comm_active == 0) return 1;
-    if (size == 0) return 1;
-    if (size == -1) {
-        int send, recv, i = 0;
-        long long t1, t2;
-        u8 tmp_buffer[queue_buff_size];
+// Returns 0 on failure, !0 on success
+static int hm2_eth_send_queued_reads(hm2_lowlevel_io_t *this) {
+    hm2_eth_t *board = this->private;
+    int send;
 
-        read_cnt++;
-        send = eth_socket_send(sockfd, (void*) &queue_packets, sizeof(lbp16_cmd_addr)*queue_reads_count, 0);
-        if(send < 0)
-            LL_PRINT("ERROR: sending packet: %s\n", strerror(errno));
-        t1 = rtapi_get_time();
-        do {
-            rtapi_delay(READ_PCK_DELAY_NS);
-            recv = eth_socket_recv(sockfd, (void*) &tmp_buffer, queue_buff_size, 0);
-            t2 = rtapi_get_time();
-            i++;
-        } while ((recv < 0) && ((t2 - t1) < 200*1000*1000));
-        LL_PRINT_IF(debug, "enqueue_read(%d) : PACKET RECV [SIZE: %d | TRIES: %d | TIME: %llu]\n", read_cnt, recv, i, t2 - t1);
-
-        for (i = 0; i < queue_reads_count; i++) {
-            memcpy(queue_reads[i].buffer, &tmp_buffer[queue_reads[i].from], queue_reads[i].size);
-        }
-
-        queue_reads_count = 0;
-        queue_buff_size = 0;
+    // Check for possible read packet buffer overflow
+    if ((board->read_packet_ptr + sizeof(lbp16_cmd_addr)*3 + sizeof(uint32_t)) > board->read_packet + sizeof(board->read_packet)) {
+        LL_PRINT("ERROR: read buffer overflow error in hm2_eth_send_queued_reads\n");
+        return 0;
+    } else if ((board->read_entry_count + 2) >= MAX_ETH_READS) {
+        LL_PRINT("ERROR: reached max queued reads already of %d in hm2_eth_send_queued_reads\n", MAX_ETH_READS);
+        return 0;
     } else {
-        LBP16_INIT_PACKET4(queue_packets[queue_reads_count], CMD_READ_HOSTMOT2_ADDR32_INCR(size/4), addr);
-        queue_reads[queue_reads_count].buffer = buffer;
-        queue_reads[queue_reads_count].size = size;
-        queue_reads[queue_reads_count].from = queue_buff_size;
-        queue_reads_count++;
-        queue_buff_size += size;
+        // read (low 16 bits of) last write number from space 4 address 0010
+        LBP16_INIT_PACKET4(*(lbp16_cmd_addr*)(board->read_packet_ptr), CMD_READ_COMM_CTRL_ADDR16(1), 0x8);
+        board->read_packet_ptr += sizeof(lbp16_cmd_addr);
+        board->read_entries[board->read_entry_count].buffer = &board->rxudpcount;
+        board->read_entries[board->read_entry_count].size = 2;
+        board->read_entries[board->read_entry_count].received_data_offset = board->total_read_buffer_size;
+        board->read_entry_count++;
+        board->total_read_buffer_size += 2;
+
+        board->read_cnt++;
+        // write then read back space 4 scratch register at 0010 to verify we got the right receive packet
+        LBP16_INIT_PACKET4(*(lbp16_cmd_addr*)(board->read_packet_ptr), CMD_WRITE_TIMER_ADDR16_INCR(2), 0x10);
+        board->read_packet_ptr += sizeof(lbp16_cmd_addr);
+        *(uint32_t*)board->read_packet_ptr = board->read_cnt;
+        board->read_packet_ptr += sizeof(uint32_t);
+
+        LBP16_INIT_PACKET4(*(lbp16_cmd_addr*)(board->read_packet_ptr), CMD_READ_TIMER_ADDR16_INCR(4), 0x10);
+        board->read_packet_ptr += sizeof(lbp16_cmd_addr);
+        board->read_entries[board->read_entry_count].buffer = &board->confirm_read_cnt;
+        board->read_entries[board->read_entry_count].size = 8;
+        board->read_entries[board->read_entry_count].received_data_offset = board->total_read_buffer_size;
+        board->read_entry_count++;
+        board->total_read_buffer_size += 8;
+
+        send = eth_socket_send(board->sockfd, (void*) &board->read_packet, board->read_packet_ptr - board->read_packet, 0);
+        if (send < 0) {
+            LL_PRINT("ERROR: sending packet: %s\n", strerror(errno));
+            if (record_soft_error(board))
+                return -EAGAIN;
+            else
+                return 0;
+        }
+        if (debug) {
+            int size = board->read_packet_ptr - board->read_packet;
+            LL_PRINT("read(%d) : PACKET SENT [SIZE: %d]\n", board->read_cnt, size);
+        }
+        return 1;
     }
-    return 1;
 }
 
-static int hm2_eth_write(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
+
+// Returns 0 on failure, !0 on success
+static int hm2_eth_receive_queued_reads(hm2_lowlevel_io_t *this) {
+    hm2_eth_t *board = this->private;
+    int recv, attempts = 0;
+    u8 tmp_buffer[board->total_read_buffer_size];
+    long long t1, t2, before_recv_time;
+    long int deltat;
+    t1 = rtapi_get_time();
+
+    // an error occurred in the past but the user has reset the io_error
+    // pin (or they did something else like fiddle with the error limit
+    // during a run, in which case we don't care if we reset the counter
+    // or not)
+    if(board->hal && board->comm_error_counter == *board->hal->packet_error_limit && !*board->llio.io_error) {
+        board->comm_error_counter = 0;
+    }
+
+    // So llio.period is documented to be the period (in ns) of the last read-request invocation
+    // unsigned long period;
+    // It is really the period argument passed into the .read function on the servo thread.
+    // At least I think - the docs for adding functions to hal threads.
+    // The servo thread period is 1,000,000 nanoseconds or 1 millisecond.
+
+    // Units on all these are nanoseconds.
+    long read_timeout = board->hal ? *board->hal->read_timeout : 800000;
+    if (read_timeout <= 0)
+        read_timeout = 80;
+
+    // If read_timeout is less than 100, it represents a percentage of the servo period so use it to scale the value
+    if (read_timeout < 100)//less than 100 is interpreted as a percentage of the thread period.
+        read_timeout = (long)((read_timeout * (unsigned long long)board->llio.period) / 100ull);
+
+    // But with a minimum of 0.1 milliseconds.
+    if (read_timeout < 100000)
+        read_timeout = 100000;
+
+    LL_PRINT_IF(debug, "read timeout %li\n", read_timeout);
+
+    if (!board->hal) this->read_time = t1;
+    unsigned long long read_deadline = this->read_time + read_timeout;
+    before_recv_time = t1;
+    do {
+do_recv_packet:
+        // This will block for up to RECV_TIMEOUT_US which is 100,000 nanoseconds. This was the floor
+        // of the timeout above anyway.  And we pulled out the rtapi_delay thing which was really just
+        // a busy wait since it had no discernable benefit.
+        errno = 0;
+        recv = eth_socket_recv(board->sockfd, (void*) &tmp_buffer, board->total_read_buffer_size, 0);
+        t2 = rtapi_get_time();
+
+        // Capture the max time we are ever stuck inside recv calls
+        deltat = (long int)(t2 - before_recv_time);
+        before_recv_time = t2;
+        if ((board->hal) && (*board->hal->packet_recv_tmax < deltat))
+            *board->hal->packet_recv_tmax = deltat;
+
+        attempts++;
+    } while (recv != board->total_read_buffer_size && t2 < read_deadline);
+
+    // Capture the max recv attempts
+    if ((board->hal) && (*board->hal->packet_recv_attempts < attempts))
+        *board->hal->packet_recv_attempts = attempts;
+
+    if (recv != board->total_read_buffer_size) {
+        // We must have timed out
+        board->read_packet_ptr = board->read_packet;
+        board->read_entry_count = 0;
+        board->total_read_buffer_size = 0;
+        if (record_soft_error(board))
+            return -EAGAIN;
+        else
+            return 0;
+    }
+
+    LL_PRINT_IF(debug, "enqueue_read(%d) : PACKET RECV [SIZE: %d | TRIES: %d | TIME: %llu]\n", board->read_cnt, recv, attempts, t2 - t1);
+
+    // Now that we have the data, copy it from the local stack buffer to the final destinations that we tracked using
+    // the array of hm2_read_entry_t structs.
+    int ii;
+    for (ii = 0; ii < board->read_entry_count; ii++) {
+        memcpy(board->read_entries[ii].buffer, &tmp_buffer[board->read_entries[ii].received_data_offset], board->read_entries[ii].size);
+    }
+
+    // This appears to be a "do-over" because the UDP packet "sequence" number wasn't what we wanted
+    // and there is more time left to read.
+    if (board->confirm_read_cnt != board->read_cnt && t2 < read_deadline) {
+        before_recv_time = rtapi_get_time();
+        if (board->hal)
+            *board->hal->packet_wrong_seq += 1;
+        goto do_recv_packet;
+    }
+
+    board->read_packet_ptr = board->read_packet;
+    board->read_entry_count = 0;
+    board->total_read_buffer_size = 0;
+
+    int result = 1;
+
+    if (board->hal) {
+        // (this means that one in 2^32 lost writes will not be diagnosed,
+        // each time board->write_cnt overflows)
+        if (board->write_cnt && board->write_cnt != board->confirm_write_cnt) {
+            LL_PRINT("write_cnt: %x   confirm_write_cnt: %x\n", board->write_cnt, board->confirm_write_cnt)
+            if (record_soft_error(board))
+                result = -EAGAIN;
+            else
+                result = 0;
+        } else {
+            decrement_soft_error(board);
+        }
+    }
+
+    // Capture the max time we ever spend inside hm2_eth_receive_queued_reads()
+    deltat = (long int) (rtapi_get_time() - t1);
+    if ((board->hal) && (*board->hal->packet_read_tmax < deltat))
+        *board->hal->packet_read_tmax = deltat;
+
+    return result;
+}
+
+// Returns 0 on failure, !0 on success
+static int hm2_eth_enqueue_read(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
+    hm2_eth_t *board = this->private;
+    if (comm_active == 0) return 1;     // Fake success
+    if (size == 0) return 1;            // Fake success
+
+    // Check for possible read packet buffer overflow
+    if ((board->read_packet_ptr + sizeof(lbp16_cmd_addr)) > board->read_packet + sizeof(board->read_packet)) {
+        LL_PRINT("ERROR: read buffer overflow error in hm2_eth_enqueue_read\n");
+        return 0;
+    } else if (board->read_entry_count >= MAX_ETH_READS) {
+        LL_PRINT("ERROR: reached max queued reads already of %d in hm2_eth_enqueue_read\n", MAX_ETH_READS);
+        return 0;
+    } else {
+        LBP16_INIT_PACKET4(*(lbp16_cmd_addr*)board->read_packet_ptr, CMD_READ_HOSTMOT2_ADDR32_INCR(size/4), addr);
+        board->read_packet_ptr += sizeof(lbp16_cmd_addr);
+
+        board->read_entries[board->read_entry_count].buffer = buffer;
+        board->read_entries[board->read_entry_count].size = size;
+        board->read_entries[board->read_entry_count].received_data_offset = board->total_read_buffer_size;
+        board->read_entry_count++;
+        board->total_read_buffer_size += size;
+        return 1;
+    }
+}
+
+// Forward prototype
+static int hm2_eth_enqueue_write(hm2_lowlevel_io_t *this, u32 addr, const void *buffer, int size);
+
+/// Documented to return 0 on failure.  !0 on success.
+static int hm2_eth_write(hm2_lowlevel_io_t *this, u32 addr, const void *buffer, int size) {
+    // If we running in a realtime task context than treat this as a queued write instead.
+    if (rtapi_task_self() >= 0)
+        return hm2_eth_enqueue_write(this, addr, buffer, size);
+
     int send;
     static struct {
         lbp16_cmd_addr wr_packet;
@@ -441,63 +804,138 @@ static int hm2_eth_write(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int si
 
     if (comm_active == 0) return 1;
     if (size == 0) return 1;
-    write_cnt++;
+    hm2_eth_t *board = this->private;
+    board->write_cnt++;
 
     memcpy(packet.tmp_buffer, buffer, size);
     LBP16_INIT_PACKET4(packet.wr_packet, CMD_WRITE_HOSTMOT2_ADDR32_INCR(size/4), addr & 0xFFFF);
 
-    send = eth_socket_send(sockfd, (void*) &packet, sizeof(lbp16_cmd_addr) + size, 0);
-    if(send < 0)
+    send = eth_socket_send(board->sockfd, (void*) &packet, sizeof(lbp16_cmd_addr) + size, 0);
+    if (send < 0) {
         LL_PRINT("ERROR: sending packet: %s\n", strerror(errno));
-    LL_PRINT_IF(debug, "write(%d): PACKET SENT [CMD:%02X%02X | ADDR: %02X%02X | SIZE: %d]\n", write_cnt, packet.wr_packet.cmd_hi, packet.wr_packet.cmd_lo,
+        record_soft_error(board);
+        return 0;
+    }
+
+    LL_PRINT_IF(debug, "write(%d): PACKET SENT [CMD:%02X%02X | ADDR: %02X%02X | SIZE: %d]\n", board->write_cnt, packet.wr_packet.cmd_hi, packet.wr_packet.cmd_lo,
       packet.wr_packet.addr_lo, packet.wr_packet.addr_hi, size);
 
     return 1;  // success
 }
 
-static int hm2_eth_enqueue_write(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
-    if (comm_active == 0) return 1;
-    if (size == 0) return 1;
-    if (size == -1) {
-        int send;
-        long long t0, t1;
 
-        write_cnt++;
-        t0 = rtapi_get_time();
-        send = eth_socket_send(sockfd, (void*) &write_packet, write_packet_size, 0);
-        if(send < 0)
-            LL_PRINT("ERROR: sending packet: %s\n", strerror(errno));
-        t1 = rtapi_get_time();
-        LL_PRINT_IF(debug, "enqueue_write(%d) : PACKET SEND [SIZE: %d | TIME: %llu]\n", write_cnt, send, t1 - t0);
-        write_packet_ptr = &write_packet;
-        write_packet_size = 0;
+// Returns 0 on failure, !0 on success
+static int hm2_eth_send_queued_writes(hm2_lowlevel_io_t *this) {
+    int send;
+    long long t0, t1;
+    hm2_eth_t *board = this->private;
+
+    // Check for possible write packet buffer overflow
+    if ((board->write_packet_ptr + sizeof(lbp16_cmd_addr) + 4) > board->write_packet + sizeof(board->write_packet)) {
+        LL_PRINT("ERROR: write buffer overflow error in hm2_eth_send_queued_writes\n");
+        return 0;
     } else {
-        lbp16_cmd_addr *packet = (lbp16_cmd_addr *) write_packet_ptr;
+        board->write_cnt++;
+        lbp16_cmd_addr *packet = (lbp16_cmd_addr *) board->write_packet_ptr;
+        LBP16_INIT_PACKET4(*packet, CMD_WRITE_TIMER_ADDR16_INCR(2), 0x14);
+        board->write_packet_ptr += sizeof(*packet);
+        memcpy(board->write_packet_ptr, &board->write_cnt, 4);
+        board->write_packet_ptr += 4;
+        board->write_packet_size += (sizeof(*packet) + 4);
 
-        LBP16_INIT_PACKET4_PTR(packet, CMD_WRITE_HOSTMOT2_ADDR32_INCR(size/4), addr);
-        write_packet_ptr += sizeof(*packet);
-        memcpy(write_packet_ptr, buffer, size);
-        write_packet_ptr += size;
-        write_packet_size += (sizeof(*packet) + size);
+        t0 = rtapi_get_time();
+        send = eth_socket_send(board->sockfd, (void*) &board->write_packet, board->write_packet_size, 0);
+        if (send < 0) {
+            LL_PRINT("ERROR: sending packet: %s\n", strerror(errno));
+            record_soft_error(board);
+            return 0;
+        }
+        t1 = rtapi_get_time();
+        LL_PRINT_IF(debug, "enqueue_write(%d) : PACKET SEND [SIZE: %d | TIME: %llu]\n", board->write_cnt, send, t1 - t0);
+        board->write_packet_ptr = board->write_packet;
+        board->write_packet_size = 0;
+        return 1;
     }
-    return 1;
 }
 
-static int hm2_eth_probe() {
+/// Documented to return 0 on failure.  !0 on success.
+static int hm2_eth_enqueue_write(hm2_lowlevel_io_t *this, u32 addr, const void *buffer, int size) {
+    hm2_eth_t *board = this->private;
+    if (comm_active == 0) return 1;     // Fake success
+    if (size == 0) return 1;            // Fake success
+
+    // Check for possible write packet buffer overflow
+    if ((board->write_packet_ptr + sizeof(lbp16_cmd_addr) + size) > board->write_packet + sizeof(board->write_packet)) {
+        LL_PRINT("ERROR: write buffer overflow error in hm2_eth_enqueue_write\n");
+        return 0;
+    } else {
+        lbp16_cmd_addr *packet = (lbp16_cmd_addr *) board->write_packet_ptr;
+        LBP16_INIT_PACKET4_PTR(packet, CMD_WRITE_HOSTMOT2_ADDR32_INCR(size/4), addr);
+        board->write_packet_ptr += sizeof(*packet);
+        memcpy(board->write_packet_ptr, buffer, size);
+        board->write_packet_ptr += size;
+        board->write_packet_size += (sizeof(*packet) + size);
+        return 1;
+    }
+}
+
+static int hm2_eth_io_reset(hm2_lowlevel_io_t *this) {
+    LL_PRINT("hm2_eth_io_reset called!\n");
+
+    // Figure out which board we should reset
+    int ii;
+    for (ii = 0; ii < MAX_ETH_BOARDS; ii++) {
+        if (this == &(boards[ii].llio)) {
+            // Bingo.
+            hm2_eth_t* pBoard = &boards[ii];
+
+            LL_PRINT("hm2_eth_io_reset: closing board!\n");
+            int ev = close_board(pBoard);
+            if (ev == 0) {
+                LL_PRINT("hm2_eth_io_reset: init board!\n");
+                ev = init_board(pBoard, board_ip[ii]);
+            }
+
+            // set io_error if we couldn't successfully reset the board io
+            if (ev != 0) {
+                LL_PRINT("hm2_eth_io_reset: failed so setting io_error = 1\n");
+                *this->io_error = 1;
+            }
+
+            return 0;
+        }
+    }
+    return 0;
+}
+
+static int llio_idx(const char *llio_name) {
+    int *idx = kvlist_lookup(&board_num, llio_name);
+    return (*idx)++;
+}
+
+static int hm2_eth_probe(hm2_eth_t *board) {
+    lbp16_cmd_addr read_packet;
+
     int ret, send, recv;
     char board_name[16] = {0, };
     char llio_name[16] = {0, };
-    hm2_eth_t *board;
 
     LBP16_INIT_PACKET4(read_packet, CMD_READ_BOARD_INFO_ADDR16_INCR(16/2), 0);
-    send = eth_socket_send(sockfd, (void*) &read_packet, sizeof(read_packet), 0);
-    if(send < 0)
+    send = eth_socket_send(board->sockfd, (void*) &read_packet, sizeof(read_packet), 0);
+    if (send < 0) {
         LL_PRINT("ERROR: sending packet: %s\n", strerror(errno));
-    recv = eth_socket_recv(sockfd, (void*) &board_name, 16, 0);
-    if(recv < 0)
+        return -errno;
+    }
+    recv = eth_socket_recv_loop(board->sockfd, (void*) &board_name, 16, 0,
+                200 * 1000 * 1000);
+    if (recv < 0) {
         LL_PRINT("ERROR: receiving packet: %s\n", strerror(errno));
+        return -errno;
+    }
 
     board = &boards[boards_count];
+    board->llio.private = board;
+    board->llio.split_read = true;
 
     if (strncmp(board_name, "7I80DB-16", 9) == 0) {
         strncpy(llio_name, board_name, 4);
@@ -567,22 +1005,57 @@ static int hm2_eth_probe() {
         board->llio.ioport_connector_name[1] = "P1";
         board->llio.fpga_part_number = "XC6SLX9";
         board->llio.num_leds = 4;
+    } else if (strncmp(board_name, "ECM1", 4) == 0) {
+        strncpy(llio_name, board_name, 4);
+
+        board->llio.num_ioport_connectors = 5;
+        board->llio.pins_per_connector = 13;
+        board->llio.ioport_connector_name[0] = "P2";
+        board->llio.ioport_connector_name[1] = "P1";
+        board->llio.ioport_connector_name[2] = "P3";
+        board->llio.ioport_connector_name[3] = "P4";
+        board->llio.ioport_connector_name[4] = "P5";
+        board->llio.fpga_part_number = "XC6SLX9";
+        board->llio.num_leds = 0;
     } else {
-        LL_PRINT("No ethernet board found\n");
-        return -ENODEV;
+        LL_PRINT("Unrecognized ethernet board found: %.16s -- port names will be wrong\n", board_name);
+        strncpy(llio_name, board_name, 4);
+        llio_name[1] = tolower(llio_name[1]);
+
+        // this is a layering violation.  it would be nice if special values
+        // (such as 0 or -1) could be passed here and the layer which can
+        // legitimately read idroms would read the values and store them, but
+        // that wasn't trivial to do.
+        u32 read_data;
+        hm2_eth_read(&board->llio, HM2_ADDR_IDROM_OFFSET, &read_data, 4);
+        unsigned int idrom_address = read_data & 0xffff;
+        hm2_idrom_t idrom;
+        memset(&idrom, 0, sizeof(idrom));
+        hm2_eth_read(&board->llio, idrom_address, &idrom, sizeof(idrom));
+
+        board->llio.num_ioport_connectors = idrom.io_ports;
+        board->llio.pins_per_connector = idrom.port_width;
+        int i;
+        for (i=0; i<board->llio.num_ioport_connectors; i++)
+            board->llio.ioport_connector_name[i] = "??";
+        board->llio.fpga_part_number = "??";
+        board->llio.num_leds = 0;
     }
 
     LL_PRINT("discovered %.*s\n", 16, board_name);
 
-    rtapi_snprintf(board->llio.name, sizeof(board->llio.name), "hm2_%.*s.%d", (int)strlen(llio_name), llio_name, boards_count);
+    rtapi_snprintf(board->llio.name, sizeof(board->llio.name), "hm2_%.*s.%d", (int)strlen(llio_name), llio_name, llio_idx(llio_name));
 
     board->llio.comp_id = comp_id;
-    board->llio.private = board;
 
+    board->llio.io_reset = hm2_eth_io_reset;
     board->llio.read = hm2_eth_read;
     board->llio.write = hm2_eth_write;
     board->llio.queue_read = hm2_eth_enqueue_read;
+    board->llio.send_queued_reads = hm2_eth_send_queued_reads;
+    board->llio.receive_queued_reads = hm2_eth_receive_queued_reads;
     board->llio.queue_write = hm2_eth_enqueue_write;
+    board->llio.send_queued_writes = hm2_eth_send_queued_writes;
 
     ret = hm2_register(&board->llio, config[boards_count]);
     if (ret != 0) {
@@ -591,15 +1064,114 @@ static int hm2_eth_probe() {
     }
     boards_count++;
 
-    int val = fcntl(sockfd, F_GETFL);
-    val = val | O_NONBLOCK;
-    fcntl(sockfd, F_SETFL, val);
+    return 0;
+}
+
+static int hm2_eth_items(hm2_eth_t *board) {
+    int r;
+
+    board->hal = (hm2_eth_global_t *)hal_malloc(sizeof(hm2_eth_global_t));
+    if (board->hal == NULL) {
+        LL_ERR("out of memory!\n");
+        return -ENOMEM;
+    }
+
+    if ((r = hal_pin_s32_newf(HAL_IO,
+            &(board->hal->read_timeout),
+            board->llio.comp_id,
+            "%s.packet-read-timeout",
+            board->llio.name)) < 0)
+        return r;
+    *board->hal->read_timeout = 80;
+
+    if ((r = hal_pin_s32_newf(HAL_IO,
+            &(board->hal->packet_error_limit),
+            board->llio.comp_id,
+            "%s.packet-error-limit",
+            board->llio.name)) < 0)
+        return r;
+    *board->hal->packet_error_limit = 10;
+
+    if ((r = hal_pin_s32_newf(HAL_IO,
+            &(board->hal->packet_error_increment),
+            board->llio.comp_id,
+            "%s.packet-error-increment",
+            board->llio.name)) < 0)
+        return r;
+    *board->hal->packet_error_increment = 2;
+
+    if ((r = hal_pin_s32_newf(HAL_OUT,
+            &(board->hal->packet_error_decrement),
+            board->llio.comp_id,
+            "%s.packet-error-decrement",
+            board->llio.name)) < 0)
+        return r;
+    *board->hal->packet_error_decrement = 1;
+
+    if ((r = hal_pin_bit_newf(HAL_OUT,
+            &(board->hal->packet_error),
+            board->llio.comp_id,
+            "%s.packet-error",
+            board->llio.name)) < 0)
+        return r;
+    *board->hal->packet_error = 0;
+
+    if ((r = hal_pin_s32_newf(HAL_OUT,
+            &(board->hal->packet_error_level),
+            board->llio.comp_id,
+            "%s.packet-error-level",
+            board->llio.name)) < 0)
+        return r;
+    *board->hal->packet_error_level = 0;
+
+    if ((r = hal_pin_bit_newf(HAL_OUT,
+            &(board->hal->packet_error_exceeded),
+            board->llio.comp_id,
+            "%s.packet-error-exceeded",
+            board->llio.name)) < 0)
+        return r;
+    *board->hal->packet_error_exceeded = 0;
+
+    if ((r = hal_pin_s32_newf(HAL_OUT,
+            &(board->hal->packet_read_tmax),
+            board->llio.comp_id,
+            "%s.packet-read-tmax",
+            board->llio.name)) < 0)
+        return r;
+    *board->hal->packet_read_tmax = 0;
+
+    if ((r = hal_pin_s32_newf(HAL_OUT,
+            &(board->hal->packet_recv_tmax),
+            board->llio.comp_id,
+            "%s.packet-recv-tmax",
+            board->llio.name)) < 0)
+        return r;
+    *board->hal->packet_recv_tmax = 0;
+
+    if ((r = hal_pin_s32_newf(HAL_OUT,
+            &(board->hal->packet_wrong_seq),
+            board->llio.comp_id,
+            "%s.packet-wrong-seq",
+            board->llio.name)) < 0)
+        return r;
+    *board->hal->packet_wrong_seq = 0;
+
+    if ((r = hal_pin_s32_newf(HAL_OUT,
+            &(board->hal->packet_recv_attempts),
+            board->llio.comp_id,
+            "%s.packet-recv-attempts",
+            board->llio.name)) < 0)
+        return r;
+    *board->hal->packet_recv_attempts = 0;
 
     return 0;
 }
 
 int rtapi_app_main(void) {
-    int ret;
+    INIT_LIST_HEAD(&ifnames);
+    INIT_LIST_HEAD(&board_num);
+
+    int ret, i;
 
     LL_PRINT("loading Mesa AnyIO HostMot2 ethernet driver version " HM2_ETH_VERSION "\n");
 
@@ -608,31 +1180,80 @@ int rtapi_app_main(void) {
         goto error0;
     comp_id = ret;
 
-    ret = init_net();
+    if (use_iptables()) clear_iptables();
+
+    for (i = 0, ret = 0; ret == 0 && i<MAX_ETH_BOARDS && board_ip[i] && *board_ip[i]; i++) {
+        ret = init_board(&boards[i], board_ip[i]);
+        if (ret < 0) board_ip[i] = 0;
+    }
+
     if (ret < 0)
         goto error1;
 
+    int num_boards = i;
     comm_active = 1;
 
-    ret = hm2_eth_probe();
+    for (i = 0; i<num_boards; i++)
+    {
+        ret = hm2_eth_probe(&boards[i]);
 
-    if (ret < 0)
-        goto error1;
+        if (ret < 0)
+            goto error1;
+
+        ret = hm2_eth_items(&boards[i]);
+
+        if (ret < 0)
+            goto error1;
+    }
+
+    for (i = 0; i<num_boards; i++) {
+        char ifbuf[64]; // more than enough for eth0
+        char *ifptr = fetch_ifname(boards[i].sockfd, ifbuf, sizeof(ifbuf));
+        if (!ifptr) {
+            LL_PRINT("failed to retrieve interface name for board");
+            continue;
+        }
+        boards[i].read_cnt = boards[i].write_cnt = 0;
+        int *added = kvlist_lookup(&ifnames, ifptr);
+        if (*added) continue;
+        install_iptables_perinterface(ifptr);
+        *added = 1;
+    }
 
     hal_ready(comp_id);
 
     return 0;
 
 error1:
-    close_net();
+    for (i = 0; i<MAX_ETH_BOARDS && board_ip[i] && board_ip[i][0]; i++) {
+        close_board(&boards[i]);
+        // Dump final stats
+        LL_PRINT("HostMot2 ethernet board %s.packet-read-tmax = %d\n", boards[i].llio.name, *boards[i].hal->packet_read_tmax);
+        LL_PRINT("HostMot2 ethernet board %s.packet-recv-tmax = %d\n", boards[i].llio.name, *boards[i].hal->packet_recv_tmax);
+        LL_PRINT("HostMot2 ethernet board %s.packet-wrong-seq = %d\n", boards[i].llio.name, *boards[i].hal->packet_wrong_seq);
+        LL_PRINT("HostMot2 ethernet board %s.packet-recv-attempts = %d\n", boards[i].llio.name, *boards[i].hal->packet_recv_attempts);
+    }
+
+    if (use_iptables()) clear_iptables();
+
 error0:
+    kvlist_free(&board_num);
+    kvlist_free(&ifnames);
     hal_exit(comp_id);
     return ret;
 }
 
 void rtapi_app_exit(void) {
+    int i;
     comm_active = 0;
-    close_net();
+    for (i = 0; i<MAX_ETH_BOARDS && board_ip[i] && board_ip[i][0]; i++)
+        close_board(&boards[i]);
+
+    if (use_iptables()) clear_iptables();
+
+    kvlist_free(&board_num);
+    kvlist_free(&ifnames);
+
     hal_exit(comp_id);
     LL_PRINT("HostMot2 ethernet driver unloaded\n");
 }

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.h
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.h
@@ -20,21 +20,64 @@
 #ifndef __INCLUDE_HM2_ETH_H
 #define __INCLUDE_HM2_ETH_H
 
+#include "lbp16.h"
+
 #define MAX_ETH_BOARDS 4
 
-#define HM2_ETH_VERSION "0.2"
+#define HM2_ETH_VERSION "0.3"
 #define HM2_LLIO_NAME "hm2_eth"
 
 #define MAX_ETH_READS 64
 
-typedef struct {
-    hm2_lowlevel_io_t llio;
-} hm2_eth_t;
-
+// These are descriptors that keep track of the outstanding async read.
 typedef struct {
     void *buffer;
     int size;
-    int from;
-} read_queue_entry_t;
+    int received_data_offset;
+} hm2_read_entry_t;
+
+typedef struct {
+  hal_s32_t *read_timeout;
+  hal_s32_t *packet_error_limit;
+  hal_s32_t *packet_error_increment;
+  hal_s32_t *packet_error_decrement;
+  hal_bit_t *packet_error;
+  hal_s32_t *packet_error_level;
+  hal_bit_t *packet_error_exceeded;
+  hal_s32_t *packet_read_tmax;
+  hal_s32_t *packet_recv_tmax;
+  hal_s32_t *packet_wrong_seq;
+  hal_s32_t *packet_recv_attempts;
+} hm2_eth_global_t;
+
+typedef struct {
+    hm2_lowlevel_io_t llio;
+
+    int sockfd;
+    struct sockaddr_in local_addr;
+    struct sockaddr_in server_addr;
+
+    u8 read_packet[1400];
+    u8 *read_packet_ptr;
+    // These track the async read requests. The request is made by sending a UDP packet. When a UDP packet is later received,
+    // these entries are iterated through and the received data split up into them - sort of like a scatter-gather pattern.
+    hm2_read_entry_t read_entries[MAX_ETH_READS];
+    int read_entry_count;
+    int total_read_buffer_size;
+
+    u8 write_packet[1400];
+    u8 *write_packet_ptr;
+    int write_packet_size;
+    uint32_t read_cnt, write_cnt;
+    // these two fields must be kept together, they're read by a single
+    // read-request
+    uint32_t confirm_read_cnt, confirm_write_cnt;
+
+    int comm_error_counter;
+    uint16_t old_rxudpcount, rxudpcount;
+    struct arpreq req;
+
+    hm2_eth_global_t *hal;
+} hm2_eth_t;
 
 #endif

--- a/src/hal/drivers/mesa-hostmot2/hm2_pci.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_pci.c
@@ -237,7 +237,7 @@ static int hm2_pci_read(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int siz
     return 1;  // success
 }
 
-static int hm2_pci_write(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
+static int hm2_pci_write(hm2_lowlevel_io_t *this, u32 addr, const void *buffer, int size) {
     hm2_pci_t *board = this->private;
     int i;
     u32* src = (u32*) buffer;

--- a/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
@@ -183,10 +183,10 @@ static int hm2_soc_read(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int siz
     return 1;  // success
 }
 
-static int hm2_soc_write(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
+static int hm2_soc_write(hm2_lowlevel_io_t *this, u32 addr, const void *buffer, int size) {
     hm2_soc_t *brd = this->private;
     int i;
-    u32* src = (u32*) buffer;
+    const u32* src = (const u32*) buffer;
     u32* dst = (u32*) (brd->base + addr);
 
     // Per Peter Wallace, all hostmot2 access should be 32 bits and 32-bit aligned
@@ -215,7 +215,7 @@ static int hm2_soc_unmapped_read(hm2_lowlevel_io_t *this, u32 addr, void *buffer
     return hm2_soc_read(this, addr, buffer, size);
 }
 
-static int hm2_soc_unmapped_write(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
+static int hm2_soc_unmapped_write(hm2_lowlevel_io_t *this, u32 addr, const void *buffer, int size) {
     hm2_soc_t *brd = this->private;
     int rc = hm2_soc_mmap(brd);
     if (rc)

--- a/src/hal/drivers/mesa-hostmot2/hm2_test.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_test.c
@@ -86,7 +86,7 @@ static int hm2_test_read(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int si
 }
 
 
-static int hm2_test_write(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
+static int hm2_test_write(hm2_lowlevel_io_t *this, u32 addr, const void *buffer, int size) {
     return 1;  // success
 }
 

--- a/src/hal/drivers/mesa-hostmot2/hostmot2-lowlevel.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2-lowlevel.h
@@ -63,30 +63,67 @@ typedef struct hm2_lowlevel_io_struct hm2_lowlevel_io_t;
 
 // FIXME: this is really a lowlevel io *instance*, or maybe a "board"
 struct hm2_lowlevel_io_struct {
-    char name[HAL_NAME_LEN+1];
+    char name[HAL_NAME_LEN-10]; // Needs to be shorter than a full HAL name because this is copied into a pin name
     int comp_id;
 
     // these two are required
     // on success these two return TRUE (not zero)
     // on failure they return FALSE (0) and set *self->io_error (below) to TRUE
     int (*read)(hm2_lowlevel_io_t *self, u32 addr, void *buffer, int size);
-    int (*write)(hm2_lowlevel_io_t *self, u32 addr, void *buffer, int size);
-
-    int (*queue_read)(hm2_lowlevel_io_t *self, u32 addr, void *buffer, int size);
-    int (*queue_write)(hm2_lowlevel_io_t *self, u32 addr, void *buffer, int size);
+    int (*write)(hm2_lowlevel_io_t *self, u32 addr, const void *buffer, int size);
 
     // these are optional
     int (*program_fpga)(hm2_lowlevel_io_t *self,
-			const bitfile_t *bitfile,
-			const struct firmware *fw);
+      const bitfile_t *bitfile,
+      const struct firmware *fw);
     int (*reset)(hm2_lowlevel_io_t *self);
 
     // use this if the firmware is not Xilinx bitfile format.
     // if NULL, uses legacy behavior (bitfile_parse_and_verify()
     int (*verify_firmware)(hm2_lowlevel_io_t *self, const struct firmware *fw);
 
+    // optional
+    // resets the communication method to the fpga - can be called by the
+    // watchdog recovery code.  primary motivation was to add this for hm2_eth.c use
+    // where it needs to close/re-open a socket due to some intermittent ethernet
+    // error that the user has resolved and they don't want to restart the entire world.
+    // if the io_reset fails, set the io_error parameter to true
+    int (*io_reset)(hm2_lowlevel_io_t *self);
 
+    // for devices with a lot of inherent latency (ethernet and spi are two
+    // examples), it is useful to divide the work of the bulk reads which occur
+    // every servo cycle into up to three groups:
+    //   * queuing the reads -- the buffer must point to storage which is stable
+    //     thrugh the eventual receive_queued_reads call
+    //   * actually requesting the queued reads
+    //   * actually receiving the read result and storing it in the buffer given in the
+    //     queue_read call
     //
+    // these routines are optional: the llio may provide any of these subsets:
+    //   * none, in which case a dummy implementation of ->queue_read delegates to
+    //     ->read
+    //   * queue_read and send_queued_reads, in which case send_queued_reads must also
+    //     receive and process the reads
+    //   * all three
+    //
+    //  Return codes?????  Undocumented.  Assuming they should behave consistent
+    //  with the read and write above which are 0 on failure and !0 on success.
+    int (*queue_read)(hm2_lowlevel_io_t *self, u32 addr, void *buffer, int size);
+    int (*send_queued_reads)(hm2_lowlevel_io_t *self);
+    int (*receive_queued_reads)(hm2_lowlevel_io_t *self);
+
+    // similarly, it is useful to divide the work of bulk writes into two groups
+    //   * queueing the writes
+    //   * actually performing the writes
+    // these routines are optional; the llio may either provide both of them, or neither
+    // (in which case a dummy implementation of ->queue_write delegates to ->write)
+    //
+    //  Return codes?????  Undocumented.  Assuming they should behave consistent
+    //  with the read and write above which are 0 on failure and !0 on success.
+    int (*queue_write)(hm2_lowlevel_io_t *self, u32 addr, const void *buffer, int size);
+    int (*send_queued_writes)(hm2_lowlevel_io_t *self);
+
+//
     // This is a HAL parameter allocated and added to HAL by hostmot2.
     //
     // * The llio driver sets it whenever it detects an I/O error.
@@ -100,9 +137,28 @@ struct hm2_lowlevel_io_struct {
     //
     hal_bit_t *io_error;
 
+    // this gets set to TRUE by .read-request and cleared by .read, in order
+    // to amortize latency on multiple ethernet devices
+    int read_requested;
+
+    // the period (in ns) of the last read-request invocation
+    unsigned long period;
+
+    // the time (in ns) that the last read-request was issued
+    unsigned long long read_time;
+
+    // TRUE if it is useful to split reads into a request and response part
+    int split_read;
+
     // this gets set to TRUE when the llio driver detects an io_error, and
     // by the hm2 watchdog (if present) when it detects a watchdog bite
+    // this requires user intervention to clear the io_error and then
+    // the needs_reset flag will be reacted to in the next
+    // hm2_watchdog_write() call.
     int needs_reset;
+
+    // !0 when recoverable errors have occurred (minor packet loss in the case of hm2_eth llio driver is an example).
+    int needs_soft_reset;
 
     // the pin-count and names of the io port connectors on this board
     int num_ioport_connectors;
@@ -143,3 +199,4 @@ void hm2_unregister(hm2_lowlevel_io_t *llio);
 
 
 #endif //  HOSTMOT2_LOWLEVEL_H
+

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.c
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.c
@@ -46,6 +46,7 @@ MODULE_LICENSE("GPL");
 
 
 
+
 int debug_idrom = 0;
 RTAPI_MP_INT(debug_idrom, "Developer/debug use only!  Enable debug logging of the HostMot2\nIDROM header.");
 
@@ -71,19 +72,51 @@ struct list_head hm2_list;
 
 static int comp_id;
 
+
+
+
 //
 // functions exported to HAL
 //
+
+static int hm2_read_request(void *void_hm2, const hal_funct_args_t *fa) {
+    hostmot2_t *hm2 = void_hm2;
+    long period = fa_current_period(fa);
+    hm2->llio->period = period;
+
+    // if there are comm problems, wait for the user to fix it
+    if (hm2_watchdog_bite_on_ioerror(hm2)) return -1;
+
+    hm2_tram_read(hm2);
+    if (hm2_watchdog_bite_on_ioerror(hm2)) return -1;
+
+    hm2_raw_queue_read(hm2);
+    hm2_tp_pwmgen_queue_read(hm2);
+    if (hm2_watchdog_bite_on_ioerror(hm2)) return -1;
+
+    hm2_queue_read(hm2);
+    hm2->llio->read_requested = true;
+    hm2->llio->read_time = rtapi_get_time();
+
+    return 0;
+}
 
 static int hm2_read(void *void_hm2, const hal_funct_args_t *fa) {
     hostmot2_t *hm2 = void_hm2;
     long period = fa_current_period(fa);
 
-    // if there are comm problems, wait for the user to fix it
-    if ((*hm2->llio->io_error) != 0) return -1;
+    if(!hm2->llio->read_requested) hm2_read_request(void_hm2, fa);
+    hm2->llio->read_requested = false;
 
-    hm2_tram_read(hm2);
-    if ((*hm2->llio->io_error) != 0) return -1;
+    // if there are comm problems, wait for the user to fix it
+    if (hm2_watchdog_bite_on_ioerror(hm2)) return -1;
+
+    // if there's a temporary read failure, don't sweat it
+    if(hm2_finish_read(hm2) == -EAGAIN) return -1;
+
+    // if there are comm problems, wait for the user to fix it
+    if (hm2_watchdog_bite_on_ioerror(hm2)) return -1;
+
     hm2_watchdog_process_tram_read(hm2);
     hm2_ioport_gpio_process_tram_read(hm2);
     hm2_encoder_process_tram_read(hm2, &hm2->encoder, period);
@@ -96,9 +129,8 @@ static int hm2_read(void *void_hm2, const hal_funct_args_t *fa) {
     hm2_absenc_process_tram_read(hm2, period);
     //UARTS need to be explicity handled by an external component
 
-    hm2_tp_pwmgen_read(hm2); // check the status of the fault bit
+    hm2_tp_pwmgen_process_read(hm2); // check the status of the fault bit
     hm2_dpll_process_tram_read(hm2, period);
-    hm2_raw_read(hm2);
     de0_nano_soc_adc_read(hm2);
     hm2_capsense_read(hm2);
     return 0;
@@ -110,7 +142,7 @@ static int hm2_write(void *void_hm2, const hal_funct_args_t *fa) {
     long period = fa_current_period(fa);
 
     // if there are comm problems, wait for the user to fix it
-    if ((*hm2->llio->io_error) != 0) return -1;
+    if (hm2_watchdog_bite_on_ioerror(hm2)) return -1;
 
     hm2_ioport_gpio_prepare_tram_write(hm2);
     hm2_pwmgen_prepare_tram_write(hm2);
@@ -136,11 +168,12 @@ static int hm2_write(void *void_hm2, const hal_funct_args_t *fa) {
     hm2_resolver_write(hm2, period); // Update the excitation frequency
     hm2_dpll_write(hm2, period); // Update the timer phases
     hm2_irq_write(hm2); // Update the irq period - after dpll call
-    hm2_led_write(hm2);	      // Update on-board LEDs
+    hm2_led_write(hm2);      // Update on-board LEDs
 
     hm2_raw_write(hm2);
 
     hm2_capsense_write(hm2); // handles set hysteresis in capsense mksocfpga hm2 core
+    hm2_finish_write(hm2);
     return 0;
 }
 
@@ -148,7 +181,7 @@ static int hm2_read_gpio(void *void_hm2, const hal_funct_args_t *fa) {
     hostmot2_t *hm2 = void_hm2;
 
     // if there are comm problems, wait for the user to fix it
-    if ((*hm2->llio->io_error) != 0) return -1;
+    if (hm2_watchdog_bite_on_ioerror(hm2)) return -1;
 
     hm2_ioport_gpio_read(hm2);
     return 0;
@@ -160,7 +193,7 @@ static int hm2_write_gpio(void *void_hm2, const hal_funct_args_t *fa) {
     long period = fa_current_period(fa);
 
     // if there are comm problems, wait for the user to fix it
-    if ((*hm2->llio->io_error) != 0) return -1;
+    if (hm2_watchdog_bite_on_ioerror(hm2)) return -1;
 
     hm2_ioport_gpio_write(hm2);
     hm2_watchdog_write(hm2, period);
@@ -1138,13 +1171,13 @@ static void hm2_release_device(struct device *dev) {
     // nothing to do here
 }
 
-static int dummy_queue_write(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
-    if(size != -1) return this->write(this, addr, buffer, size);
+static int dummy_queue_write(hm2_lowlevel_io_t *this, u32 addr, const void *buffer, int size) {
+    if(size >= 0) return this->write(this, addr, buffer, size);
     return 1; // success
 }
 
 static int dummy_queue_read(hm2_lowlevel_io_t *this, u32 addr, void *buffer, int size) {
-    if(size != -1) return this->read(this, addr, buffer, size);
+    if(size >= 0) return this->read(this, addr, buffer, size);
     return 1; // success
 }
 
@@ -1186,6 +1219,45 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
         if (i == 0) {
             HM2_ERR_NO_LL("invalid llio name passed in (zero length)\n");
             return -EINVAL;
+        }
+    }
+
+
+    //
+    // verify llio ioport connector names
+    //
+
+    if ((llio->num_ioport_connectors < 1) || (llio->num_ioport_connectors > ANYIO_MAX_IOPORT_CONNECTORS)) {
+        HM2_ERR_NO_LL("llio reports invalid number of I/O connectors (%d)\n", llio->num_ioport_connectors);
+        return -EINVAL;
+    }
+
+    {
+        int port;
+
+        for (port = 0; port < llio->num_ioport_connectors; port ++) {
+            int i;
+
+            if (llio->ioport_connector_name[port] == NULL) {
+                HM2_ERR_NO_LL("llio ioport connector name %d is NULL\n", port);
+                return -EINVAL;
+            }
+
+            for (i = 0; i < HAL_NAME_LEN+1; i ++) {
+                if (llio->ioport_connector_name[port][i] == '\0') break;
+                if (!isprint(llio->ioport_connector_name[port][i])) {
+                    HM2_ERR_NO_LL("invalid llio ioport connector name %d passed in (contains non-printable character)\n", port);
+                    return -EINVAL;
+                }
+            }
+            if (i == HAL_NAME_LEN+1) {
+                HM2_ERR_NO_LL("invalid llio ioport connector name %d passed in (not NULL terminated)\n", port);
+                return -EINVAL;
+            }
+            if (i == 0) {
+                HM2_ERR_NO_LL("invalid llio ioport connector name %d passed in (zero length)\n", port);
+                return -EINVAL;
+            }
         }
     }
 
@@ -1366,7 +1438,7 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
 
 
     //
-    // export a parameter to deal with communication errors
+    // export a pin to deal with communication errors
     // NOTE: this is really only useful for EPP boards, PCI doesnt use it
     //
 
@@ -1392,13 +1464,14 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
         }
     }
 
+    HM2_PRINT("Low Level init %s\n", HM2_VERSION);
 
     //
     // read & verify FPGA firmware IOCookie
     //
 
     {
-        u32 cookie;
+        uint32_t cookie;
 
         if (!llio->read(llio, HM2_ADDR_IOCOOKIE, &cookie, 4)) {
             HM2_ERR("error reading hm2 cookie\n");
@@ -1426,44 +1499,6 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
     } else
 	HM2_INFO("skipping fwid parse");
 
-
-    //
-    // verify llio ioport connector names
-    //
-
-    if ((llio->num_ioport_connectors < 1) || (llio->num_ioport_connectors > ANYIO_MAX_IOPORT_CONNECTORS)) {
-        HM2_ERR_NO_LL("llio reports invalid number of I/O connectors (%d)\n", llio->num_ioport_connectors);
-        return -EINVAL;
-    }
-
-    {
-        int port;
-
-        for (port = 0; port < llio->num_ioport_connectors; port ++) {
-            int i;
-
-            if (llio->ioport_connector_name[port] == NULL) {
-                HM2_ERR_NO_LL("llio ioport connector name %d is NULL\n", port);
-                return -EINVAL;
-            }
-
-            for (i = 0; i < HAL_NAME_LEN+1; i ++) {
-                if (llio->ioport_connector_name[port][i] == '\0') break;
-                if (!isprint(llio->ioport_connector_name[port][i])) {
-                    HM2_ERR_NO_LL("invalid llio ioport connector name %d passed in (contains non-printable character)\n", port);
-                    return -EINVAL;
-                }
-            }
-            if (i == HAL_NAME_LEN+1) {
-                HM2_ERR_NO_LL("invalid llio ioport connector name %d passed in (not NULL terminated)\n", port);
-                return -EINVAL;
-            }
-            if (i == 0) {
-                HM2_ERR_NO_LL("invalid llio ioport connector name %d passed in (zero length)\n", port);
-                return -EINVAL;
-            }
-        }
-    }
 
     //
     // read & verify FPGA firmware ConfigName
@@ -1550,6 +1585,7 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
 
     r = hm2_ioport_gpio_export_hal(hm2);
     if (r != 0) {
+        HM2_ERR("error exporting gpio pins\n");
         goto fail1;
     }
 
@@ -1559,6 +1595,7 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
 
     r = hm2_raw_setup(hm2);
     if (r != 0) {
+        HM2_ERR("error setting up raw interface\n");
         goto fail1;
     }
 
@@ -1569,6 +1606,7 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
 
     r = hm2_adc_setup(hm2);
     if (r != 0) {
+        HM2_ERR("error setting up ADC\n");
         goto fail1;
     }
 
@@ -1605,6 +1643,19 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
 
     r = hm2_tram_read(hm2);
     if (r != 0) {
+        HM2_ERR("error reading TRAM\n");
+        goto fail1;
+    }
+
+    r = hm2_queue_read(hm2);
+    if (r != 0) {
+        HM2_ERR("error executing queued read\n");
+        goto fail1;
+    }
+
+    r = hm2_finish_read(hm2);
+    if (r != 0) {
+        HM2_ERR("error finishing read\n");
         goto fail1;
     }
 
@@ -1621,6 +1672,7 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
     // initialize step accumulator, hal count & position to 0
     hm2_stepgen_tram_init(hm2);
     hm2_stepgen_process_tram_read(hm2, 1000);
+
 
     //
     // write the TRAM one first time
@@ -1639,9 +1691,15 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
 
     r = hm2_tram_write(hm2);
     if (r != 0) {
+        HM2_ERR("error writing TRAM\n");
         goto fail1;
     }
 
+    r = hm2_finish_write(hm2);
+    if (r != 0) {
+        HM2_ERR("error finishing write\n");
+        goto fail1;
+    }
 
     //
     // final check for comm errors
@@ -1684,7 +1742,23 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
     //
 
     {
-	int r;
+    if(hm2->llio->split_read) {
+        hal_export_xfunct_args_t read_request_args = {
+            .type = FS_XTHREADFUNC,
+            .funct.x = hm2_read_request,
+            .arg = hm2,
+            .uses_fp = 1,
+            .reentrant = 0,
+            .owner_id = hm2->llio->comp_id
+        };
+        if ((r = hal_export_xfunctf(&read_request_args,
+                                    "%s.read-request",
+                                    hm2->llio->name)) != 0) {
+            HM2_ERR("hal_export_xfunctf(%s.read-request) failed: %d\n",
+                    hm2->llio->name, r);
+            return r;
+        }
+    }
 
 	hal_export_xfunct_args_t read_args = {
 	    .type = FS_XTHREADFUNC,
@@ -1760,6 +1834,7 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
 	}
 
     }
+
 
     //
     // found one!

--- a/src/hal/drivers/mesa-hostmot2/ioport.c
+++ b/src/hal/drivers/mesa-hostmot2/ioport.c
@@ -155,7 +155,7 @@ int hm2_ioport_parse_md(hostmot2_t *hm2, int md_index) {
         hm2->ioport.open_drain_reg[i] = 0;         // none are open drain
         hm2->ioport.written_open_drain[i] = 0;     // starting out in sync
         hm2->ioport.output_invert_reg[i] = 0;      // none are output-inverted
-        hm2->ioport.written_output_invert[i] = 0;  // starting out in sync 
+        hm2->ioport.written_output_invert[i] = 0;  // starting out in sync
     }
 
     // we can't export this one to HAL yet, because some pins may be allocated to other modules
@@ -541,6 +541,7 @@ void hm2_ioport_gpio_read(hostmot2_t *hm2) {
     // this should never happen - what's an AnyIO board without IO?
     if (hm2->ioport.num_instances <= 0) return;
 
+    // llio->read is OK here, as this function is not used by hm2_eth
     hm2->llio->read(
         hm2->llio,
         hm2->ioport.data_addr,
@@ -592,5 +593,3 @@ void hm2_ioport_gpio_write(hostmot2_t *hm2) {
         hm2->ioport.num_instances * sizeof(u32)
     );
 }
-
-

--- a/src/hal/drivers/mesa-hostmot2/lbp16.h
+++ b/src/hal/drivers/mesa-hostmot2/lbp16.h
@@ -89,6 +89,7 @@
 #define CMD_WRITE_HOSTMOT2_ADDR32(size)       (CMD_WRITE_ADDR_32 | LBP16_SPACE_HM2 | ((size) & LBP16_MAX_PACKET_DATA_SIZE))
 #define CMD_WRITE_HOSTMOT2_ADDR32_INCR(size)  (CMD_WRITE_ADDR_32 | LBP16_SPACE_HM2 | LBP16_ADDR_AUTO_INC | ((size) & LBP16_MAX_PACKET_DATA_SIZE))
 #define CMD_WRITE_FPGA_FLASH_ADDR32(size)     (CMD_WRITE_ADDR_32 | LBP16_SPACE_FPGA_FLASH | ((size) & LBP16_MAX_PACKET_DATA_SIZE))
+#define CMD_WRITE_TIMER_ADDR16_INCR(size)     (CMD_WRITE_ADDR_16 | LBP16_SPACE_TIMER | LBP16_ADDR_AUTO_INC | ((size) & LBP16_MAX_PACKET_DATA_SIZE))
 #define CMD_WRITE_COMM_CTRL_ADDR16(size)      (CMD_WRITE_ADDR_16 | LBP16_SPACE_COMM_CTRL | ((size) & LBP16_MAX_PACKET_DATA_SIZE))
 #define CMD_WRITE_ETH_EEPROM_ADDR16(size)     (CMD_WRITE_ADDR_16 | LBP16_SPACE_ETH_EEPROM | ((size) & LBP16_MAX_PACKET_DATA_SIZE))
 #define CMD_WRITE_ETH_EEPROM_ADDR16_INCR(size) (CMD_WRITE_ADDR_16_INCR | LBP16_SPACE_ETH_EEPROM | ((size) & LBP16_MAX_PACKET_DATA_SIZE))
@@ -156,37 +157,37 @@ typedef struct {
 } lbp16_write_ip_addr_packets;
 
 #define LBP16_INIT_PACKET4(packet, cmd, addr) do { \
-    packet.cmd_hi = LO_BYTE(cmd); \
-    packet.cmd_lo = HI_BYTE(cmd); \
-    packet.addr_hi = LO_BYTE(addr); \
-    packet.addr_lo = HI_BYTE(addr); \
+    (packet).cmd_hi = LO_BYTE(cmd); \
+    (packet).cmd_lo = HI_BYTE(cmd); \
+    (packet).addr_hi = LO_BYTE(addr); \
+    (packet).addr_lo = HI_BYTE(addr); \
     } while (0);
 
 #define LBP16_INIT_PACKET4_PTR(packet, cmd, addr) do { \
-    packet->cmd_hi = LO_BYTE(cmd); \
-    packet->cmd_lo = HI_BYTE(cmd); \
-    packet->addr_hi = LO_BYTE(addr); \
-    packet->addr_lo = HI_BYTE(addr); \
+    (packet)->cmd_hi = LO_BYTE(cmd); \
+    (packet)->cmd_lo = HI_BYTE(cmd); \
+    (packet)->addr_hi = LO_BYTE(addr); \
+    (packet)->addr_lo = HI_BYTE(addr); \
     } while (0);
 
 #define LBP16_INIT_PACKET6(packet, cmd, addr, data) do { \
-    packet.cmd_hi = LO_BYTE(cmd); \
-    packet.cmd_lo = HI_BYTE(cmd); \
-    packet.addr_hi = LO_BYTE(addr); \
-    packet.addr_lo = HI_BYTE(addr); \
-    packet.data_hi = LO_BYTE(data); \
-    packet.data_lo = HI_BYTE(data); \
+    (packet).cmd_hi = LO_BYTE(cmd); \
+    (packet).cmd_lo = HI_BYTE(cmd); \
+    (packet).addr_hi = LO_BYTE(addr); \
+    (packet).addr_lo = HI_BYTE(addr); \
+    (packet).data_hi = LO_BYTE(data); \
+    (packet).data_lo = HI_BYTE(data); \
     } while (0);
 
 #define LBP16_INIT_PACKET8(packet, cmd, addr, data) do { \
-    packet.cmd_hi = LO_BYTE(cmd); \
-    packet.cmd_lo = HI_BYTE(cmd); \
-    packet.addr_hi = LO_BYTE(addr); \
-    packet.addr_lo = HI_BYTE(addr); \
-    packet.data1 = LO_BYTE(data); \
-    packet.data2 = HI_BYTE(data); \
-    packet.data3 = LO_BYTE((data >> 16) & 0xFFFF); \
-    packet.data4 = HI_BYTE((data >> 16) & 0xFFFF); \
+    (packet).cmd_hi = LO_BYTE(cmd); \
+    (packet).cmd_lo = HI_BYTE(cmd); \
+    (packet).addr_hi = LO_BYTE(addr); \
+    (packet).addr_lo = HI_BYTE(addr); \
+    (packet).data1 = LO_BYTE(data); \
+    (packet).data2 = HI_BYTE(data); \
+    (packet).data3 = LO_BYTE((data >> 16) & 0xFFFF); \
+    (packet).data4 = HI_BYTE((data >> 16) & 0xFFFF); \
     } while (0);
 
 typedef struct {

--- a/src/hal/drivers/mesa-hostmot2/raw.c
+++ b/src/hal/drivers/mesa-hostmot2/raw.c
@@ -106,10 +106,10 @@ int hm2_raw_setup(hostmot2_t *hm2) {
 
 
 
-void hm2_raw_read(hostmot2_t *hm2) {
+void hm2_raw_queue_read(hostmot2_t *hm2) {
     if (hm2->config.enable_raw == 0) return;
 
-    hm2->llio->read(
+    hm2->llio->queue_read(
         hm2->llio,
         *hm2->raw->hal.pin.read_address & 0xffff,
         (void *)hm2->raw->hal.pin.read_data,

--- a/src/hal/drivers/mesa-hostmot2/tp_pwmgen.c
+++ b/src/hal/drivers/mesa-hostmot2/tp_pwmgen.c
@@ -187,9 +187,12 @@ force_write:
 //
 // Read the fault bit for each instance
 //
-void hm2_tp_pwmgen_read(hostmot2_t *hm2) {
+void hm2_tp_pwmgen_queue_read(hostmot2_t *hm2) {
+    hm2->llio->queue_read(hm2->llio, hm2->tp_pwmgen.enable_addr, hm2->tp_pwmgen.enable_reg, (hm2->tp_pwmgen.num_instances * sizeof(u32)));
+}
+
+void hm2_tp_pwmgen_process_read(hostmot2_t *hm2) {
     int i;
-    hm2->llio->read(hm2->llio, hm2->tp_pwmgen.enable_addr, hm2->tp_pwmgen.enable_reg, (hm2->tp_pwmgen.num_instances * sizeof(u32)));
     for (i = 0 ; i < hm2->tp_pwmgen.num_instances ; i++) {
         *hm2->tp_pwmgen.instance[i].hal.pin.fault
             = (hm2->tp_pwmgen.enable_reg[i] & 2);
@@ -299,7 +302,7 @@ int hm2_tp_pwmgen_parse_md(hostmot2_t *hm2, int md_index) {
 
         // this hal parameter affects all the 3-Phase pwmgen instances
         r = hal_pin_u32_newf(
-	    HAL_IN,
+	    HAL_IO,
 	    &(hm2->tp_pwmgen.hal->pin.pwm_frequency),
 	    hm2->llio->comp_id,
 	    "%s.3pwmgen.frequency",
@@ -352,28 +355,28 @@ int hm2_tp_pwmgen_parse_md(hostmot2_t *hm2, int md_index) {
             }
 
             rtapi_snprintf(name, sizeof(name), "%s.3pwmgen.%02d.scale", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->tp_pwmgen.instance[i].hal.pin.scale), hm2->llio->comp_id);
+            r = hal_pin_float_new(name, HAL_IO, &(hm2->tp_pwmgen.instance[i].hal.pin.scale), hm2->llio->comp_id);
             if (r < 0) {
                 HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail2;
             }
 
 	    rtapi_snprintf(name, sizeof(name), "%s.3pwmgen.%02d.deadtime", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->tp_pwmgen.instance[i].hal.pin.deadzone), hm2->llio->comp_id);
+            r = hal_pin_float_new(name, HAL_IO, &(hm2->tp_pwmgen.instance[i].hal.pin.deadzone), hm2->llio->comp_id);
             if (r < 0) {
                 HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail2;
             }
 
 	    rtapi_snprintf(name, sizeof(name), "%s.3pwmgen.%02d.fault-invert", hm2->llio->name, i);
-            r = hal_pin_bit_new(name, HAL_IN, &(hm2->tp_pwmgen.instance[i].hal.pin.faultpolarity), hm2->llio->comp_id);
+            r = hal_pin_bit_new(name, HAL_IO, &(hm2->tp_pwmgen.instance[i].hal.pin.faultpolarity), hm2->llio->comp_id);
             if (r < 0) {
                 HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail2;
             }
 
 	    rtapi_snprintf(name, sizeof(name), "%s.3pwmgen.%02d.sample-time", hm2->llio->name, i);
-            r = hal_pin_float_new(name, HAL_IN, &(hm2->tp_pwmgen.instance[i].hal.pin.sampletime), hm2->llio->comp_id);
+            r = hal_pin_float_new(name, HAL_IO, &(hm2->tp_pwmgen.instance[i].hal.pin.sampletime), hm2->llio->comp_id);
             if (r < 0) {
                 HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail2;

--- a/src/hal/drivers/mesa-hostmot2/uart.c
+++ b/src/hal/drivers/mesa-hostmot2/uart.c
@@ -264,6 +264,7 @@ int hm2_uart_send(char *name,  unsigned char data[], int count)
     }
 }
 
+// This function needs to be modified so that it does not call llio->read, which hurts performance on hm2-eth
 EXPORT_SYMBOL_GPL(hm2_uart_read);
 int hm2_uart_read(char *name, unsigned char data[])
 {


### PR DESCRIPTION
This patch back ports a newer version of the hostmot2 driver which support multiple boards on one host.

Note that I haven't tested the patch against new Python3 branch yet. I'll let you know once I've successfully done that. Moreover, some testing against the SoC-based platforms may be useful as well.