### PR TITLE
Zultron/2020 09 29 halscope libs pr

### DIFF
--- a/debian/configure.py
+++ b/debian/configure.py
@@ -66,6 +66,11 @@ class Configure_script():
             self.commit_count,
             self.git_sha[0:9],
             self.distro_codename)
+        self.machinekit_hal_tarball_string = "{0}.{1}.{2}".format(
+            self.major_version,
+            self.minor_version,
+            self.commit_count,
+        )
 
     def get_machinekit_hal_changelog_data(self: object) -> None:
         control_template_file = "{}/debian/control.in".format(
@@ -176,7 +181,7 @@ class Configure_script():
 
     def create_tarball(self: object, output_path) -> None:
         tarball_file = "{0}/machinekit-hal_{1}.orig.tar.gz".format(
-            output_path, self.machinekit_hal_version_string)
+            output_path, self.machinekit_hal_tarball_string)
         sh.git("archive",
                "--format=tar.gz",
                "-o",

--- a/debian/rules
+++ b/debian/rules
@@ -25,10 +25,6 @@ endif
 # dpkg-shlibdeps warning exclusions
 SHLIBDEPS_X :=  # add patterns here
 #
-# halmeter halscope link to $(GTK_LIBS), which includes
-# several libs that aren't used (but several that are needed)
-SHLIBDEPS_X += halmeter halscope
-#
 # mb2hal gs2_vfd hy_vfd link to libglib-2.0.so.0; similar to above
 SHLIBDEPS_X += mb2hal gs2_vfd hy_vfd
 


### PR DESCRIPTION
Packaging is missing deps for `libgtk2.0`, breaking `halscope`.

Also fix `.orig` tarball name when building packages.