### PR TITLE
Transcode TXT field to dbus.Bytes for Python3 Avahi service

### DIFF
--- a/lib/python/machinekit/service.py
+++ b/lib/python/machinekit/service.py
@@ -47,7 +47,8 @@ class ZeroconfService(object):
 
         # insert fqdn in announcement
         fqdn = str(server.GetHostNameFqdn())
-        text = [t % {'fqdn': fqdn} for t in self.text]
+        text = avahi.string_array_to_txt_array(
+            [t % {'fqdn': fqdn} for t in self.text])
         name = self.name % {'fqdn': fqdn}
 
         iface = avahi.IF_UNSPEC
@@ -114,7 +115,8 @@ class Service(object):
 
         if name is None:
             pid = os.getpid()
-            self.name = '%s service on %s pid %i' % (self.type.title(), self.host, pid)
+            self.name = '%s service on %s pid %i' % (
+                self.type.title(), self.host, pid)
 
         me = uuid.uuid1()
         self.status_txtrec = [


### PR DESCRIPTION
This pull request implements partial solution to the problem described in machinekit/machinekit-hal#324:

- String representation issue stemming from Python 2 -> Python 3 transformation in TXT field of DBus message when publishing new Services with Avahi daemon