### PR TITLE
Hm2 work

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_soc_ol.c
@@ -720,17 +720,17 @@ static int locate_uio_device(hm2_soc_t *brd, const char *name)
 {
     char buf[MAXNAMELEN];
     int uio_id;
-
     for (uio_id = 0; uio_id < MAXUIOIDS; uio_id++) {
-	if (rtapi_fs_read(buf, MAXNAMELEN, "/sys/class/uio/uio%d/name", uio_id) < 0)
-	    continue;
-	if (strncmp(name, buf, strlen(name)) == 0)
-	    break;
+        if (rtapi_fs_read(buf, MAXNAMELEN, "/sys/class/uio/uio%d/name", uio_id) < 0)
+            continue;
+        if (strncmp(name, buf, strlen(name)) == 0)
+            break;
     }
     if (uio_id >= MAXUIOIDS)
 	return -1;
 
     rtapi_snprintf(buf, sizeof(buf), "/dev/uio%d", uio_id);
     brd->uio_dev = strdup(buf);
+    LL_DBG("located %s on %s\n", brd->name, brd->uio_dev);
     return 0;
 }


### PR DESCRIPTION
Some things came up while working on adding the new MyirTech FZ3 arm64 mksocfpga board:

The new board has multiple uio ports so:
Added a hm2_soc_ol debug message indicating which uio port the hostmot/mesa interface was correctly detected on.

Added support for multiple uio ports to the mksocmemio utility