### PR TITLE
hm2: make params pins

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/encoder.c
+++ b/src/hal/drivers/mesa-hostmot2/encoder.c
@@ -85,37 +85,37 @@ static void hm2_encoder_update_control_register(hostmot2_t *hm2,
 
         do_flag(
             &encoder->control_reg[i],
-            e->hal.param.index_invert,
+            *e->hal.pin.index_invert,
             HM2_ENCODER_INDEX_POLARITY
         );
 
         do_flag(
             &encoder->control_reg[i],
-            e->hal.param.index_mask,
+            *e->hal.pin.index_mask,
             HM2_ENCODER_INDEX_MASK
         );
 
         do_flag(
             &encoder->control_reg[i],
-            e->hal.param.index_mask_invert,
+            *e->hal.pin.index_mask_invert,
             HM2_ENCODER_INDEX_MASK_POLARITY
         );
 
         do_flag(
             &encoder->control_reg[i],
-            e->hal.param.counter_mode,
+            *e->hal.pin.counter_mode,
             HM2_ENCODER_COUNTER_MODE
         );
 
         do_flag(
             &hm2->encoder.control_reg[i],
-            e->hal.param.index_mode,
+            *e->hal.pin.index_mode,
             HM2_ENCODER_INDEX_MODE
         );
 
         do_flag(
             &encoder->control_reg[i],
-            e->hal.param.filter,
+            *e->hal.pin.filter,
             HM2_ENCODER_FILTER
         );
     }
@@ -548,58 +548,58 @@ int hm2_encoder_parse_md(hostmot2_t *hm2, hm2_encoder_t *encoder, int md_index, 
 
             // parameters
             rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.scale", hm2->llio->name, i + hm2->encoder_base);
-            r = hal_param_float_new(name, HAL_RW, &(encoder->instance[i].hal.param.scale), hm2->llio->comp_id);
+            r = hal_pin_float_new(name, HAL_IO, &(encoder->instance[i].hal.pin.scale), hm2->llio->comp_id);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
             }
 
             rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.index-invert", hm2->llio->name, i + hm2->encoder_base);
-            r = hal_param_bit_new(name, HAL_RW, &(encoder->instance[i].hal.param.index_invert), hm2->llio->comp_id);
+            r = hal_pin_bit_new(name, HAL_IO, &(encoder->instance[i].hal.pin.index_invert), hm2->llio->comp_id);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
             }
 
             rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.index-mask", hm2->llio->name, i + hm2->encoder_base);
-            r = hal_param_bit_new(name, HAL_RW, &(encoder->instance[i].hal.param.index_mask), hm2->llio->comp_id);
+            r = hal_pin_bit_new(name, HAL_IO, &(encoder->instance[i].hal.pin.index_mask), hm2->llio->comp_id);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
             }
 
             rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.index-mask-invert", hm2->llio->name, i + hm2->encoder_base);
-            r = hal_param_bit_new(name, HAL_RW, &(encoder->instance[i].hal.param.index_mask_invert), hm2->llio->comp_id);
+            r = hal_pin_bit_new(name, HAL_IO, &(encoder->instance[i].hal.pin.index_mask_invert), hm2->llio->comp_id);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
             }
 
             rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.counter-mode", hm2->llio->name, i + hm2->encoder_base);
-            r = hal_param_bit_new(name, HAL_RW, &(encoder->instance[i].hal.param.counter_mode), hm2->llio->comp_id);
+            r = hal_pin_bit_new(name, HAL_IO, &(encoder->instance[i].hal.pin.counter_mode), hm2->llio->comp_id);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
             }
 
             rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.index-mode", hm2->llio->name, i);
-            r = hal_param_bit_new(name, HAL_RW, &(encoder->instance[i].hal.param.index_mode), hm2->llio->comp_id);
+            r = hal_pin_bit_new(name, HAL_IO, &(encoder->instance[i].hal.pin.index_mode), hm2->llio->comp_id);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
             }
 
             rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.filter", hm2->llio->name, i + hm2->encoder_base);
-            r = hal_param_bit_new(name, HAL_RW, &(encoder->instance[i].hal.param.filter), hm2->llio->comp_id);
+            r = hal_pin_bit_new(name, HAL_IO, &(encoder->instance[i].hal.pin.filter), hm2->llio->comp_id);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
             }
 
             rtapi_snprintf(name, sizeof(name), "%s.encoder.%02d.vel-timeout", hm2->llio->name, i + hm2->encoder_base);
-            r = hal_param_float_new(name, HAL_RW, &(encoder->instance[i].hal.param.vel_timeout), hm2->llio->comp_id);
+            r = hal_pin_float_new(name, HAL_IO, &(encoder->instance[i].hal.pin.vel_timeout), hm2->llio->comp_id);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
             }
 
@@ -612,13 +612,13 @@ int hm2_encoder_parse_md(hostmot2_t *hm2, hm2_encoder_t *encoder, int md_index, 
             *encoder->instance[i].hal.pin.reset = 0;
             *encoder->instance[i].hal.pin.index_enable = 0;
 
-            encoder->instance[i].hal.param.scale = 1.0;
-            encoder->instance[i].hal.param.index_invert = 0;
-            encoder->instance[i].hal.param.index_mask = 0;
-            encoder->instance[i].hal.param.index_mask_invert = 0;
-            encoder->instance[i].hal.param.counter_mode = 0;
-            encoder->instance[i].hal.param.filter = 1;
-            encoder->instance[i].hal.param.vel_timeout = 0.5;
+            *encoder->instance[i].hal.pin.scale = 1.0;
+            *encoder->instance[i].hal.pin.index_invert = 0;
+            *encoder->instance[i].hal.pin.index_mask = 0;
+            *encoder->instance[i].hal.pin.index_mask_invert = 0;
+            *encoder->instance[i].hal.pin.counter_mode = 0;
+            *encoder->instance[i].hal.pin.filter = 1;
+            *encoder->instance[i].hal.pin.vel_timeout = 0.5;
 
 
             encoder->instance[i].state = HM2_ENCODER_STOPPED;
@@ -874,8 +874,8 @@ static void hm2_encoder_instance_update_position(hostmot2_t *hm2,
     // the scaled position.
     //
 
-    *e->hal.pin.position = *e->hal.pin.count / e->hal.param.scale;
-    *e->hal.pin.position_latch = *e->hal.pin.count_latch / e->hal.param.scale;
+    *e->hal.pin.position = *e->hal.pin.count / *e->hal.pin.scale;
+    *e->hal.pin.position_latch = *e->hal.pin.count_latch / *e->hal.pin.scale;
 }
 
 
@@ -892,9 +892,9 @@ static void hm2_encoder_instance_process_tram_read(hostmot2_t *hm2,
     hm2_encoder_instance_t *e = &encoder->instance[instance];
 
     // sanity check
-    if (e->hal.param.scale == 0.0) {
+    if (*(e->hal.pin.scale) == 0.0) {
         HM2_ERR("encoder.%02d.scale == 0.0, bogus, setting to 1.0\n", instance);
-        e->hal.param.scale = 1.0;
+        *(e->hal.pin.scale) = 1.0;
     }
 
     hm2_encoder_read_control_register(hm2, encoder);
@@ -964,19 +964,19 @@ static void hm2_encoder_instance_process_tram_read(hostmot2_t *hm2,
                 dT_clocks = (time_of_interest - e->prev_event_reg_timestamp) + (e->tsc_num_rollovers << 16);
                 dT_s = (double)dT_clocks * encoder->seconds_per_tsdiv_clock;
 
-                if (dT_s >= e->hal.param.vel_timeout) {
+                if (dT_s >= *e->hal.pin.vel_timeout) {
                     *e->hal.pin.velocity = 0.0;
                     e->state = HM2_ENCODER_STOPPED;
                     break;
                 }
 
-                if ((*e->hal.pin.velocity * e->hal.param.scale) > 0.0) {
+                if ((*e->hal.pin.velocity * *e->hal.pin.scale) > 0.0) {
                     dS_counts = 1;
                 } else {
                     dS_counts = -1;
                 }
 
-                dS_pos_units = dS_counts / e->hal.param.scale;
+                dS_pos_units = dS_counts / *e->hal.pin.scale;
 
                 // we can calculate velocity only if timestamp changed along with counts
                 if (dT_clocks > 0) {
@@ -1028,7 +1028,7 @@ static void hm2_encoder_instance_process_tram_read(hostmot2_t *hm2,
                     dT_clocks = (time_of_interest - e->prev_event_reg_timestamp) + (e->tsc_num_rollovers << 16);
                     dT_s = (double)dT_clocks * encoder->seconds_per_tsdiv_clock;
 
-                    dS_pos_units = dS_counts / e->hal.param.scale;
+                    dS_pos_units = dS_counts / *e->hal.pin.scale;
 
                     // we can calculate velocity only if timestamp changed along with counts
                     if (dT_clocks > 0) {

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -254,13 +254,10 @@ typedef struct {
             hal_bit_t *in;
             hal_bit_t *in_not;
             hal_bit_t *out;
+            hal_bit_t *is_output;
+            hal_bit_t *is_opendrain;
+            hal_bit_t *invert_output;
         } pin;
-
-        struct {
-            hal_bit_t is_output;
-            hal_bit_t is_opendrain;
-            hal_bit_t invert_output;
-        } param;
 
     } hal;
 } hm2_gpio_instance_t;
@@ -352,17 +349,15 @@ typedef struct {
             hal_bit_t *input_a;
             hal_bit_t *input_b;
             hal_bit_t *input_idx;
+            hal_float_t *scale;
+            hal_bit_t *index_invert;
+            hal_bit_t *index_mask;
+            hal_bit_t *index_mask_invert;
+            hal_bit_t *counter_mode;
+            hal_bit_t *index_mode;
+            hal_bit_t *filter;
+            hal_float_t *vel_timeout;
         } pin;
-        struct {
-            hal_float_t scale;
-            hal_bit_t index_invert;
-            hal_bit_t index_mask;
-            hal_bit_t index_mask_invert;
-            hal_bit_t counter_mode;
-            hal_bit_t index_mode;
-            hal_bit_t filter;
-            hal_float_t vel_timeout;
-        } param;
 
     } hal;
 
@@ -386,7 +381,7 @@ typedef struct {
 } hm2_encoder_instance_t;
 
 
-// these hal params affect all encoder instances
+// these hal pins affect all encoder instances
 typedef struct {
     struct {
         hal_u32_t *sample_frequency;
@@ -485,13 +480,10 @@ typedef struct {
             hal_bit_t *reset;
             hal_bit_t *index_enable;
             hal_bit_t *error;
+            hal_float_t *scale;
+            hal_float_t *vel_scale;
+            hal_u32_t *index_div;
         } pin;
-
-        struct {
-            hal_float_t scale;
-            hal_float_t vel_scale;
-            hal_u32_t index_div;
-        } param;
 
     } hal;
 
@@ -504,8 +496,8 @@ typedef struct {
 
 typedef struct {
     struct {
-        hal_float_t excitation_khz;
-    } param;
+        hal_float_t *excitation_khz;
+    } pin;
 } hm2_resolver_global_t;
 
 typedef struct {
@@ -555,12 +547,9 @@ typedef struct {
         struct {
             hal_float_t *value;
             hal_bit_t *enable;
+            hal_float_t *scale;
+            hal_s32_t *output_type;
         } pin;
-
-        struct {
-            hal_float_t scale;
-            hal_s32_t output_type;
-        } param;
 
     } hal;
 
@@ -574,12 +563,12 @@ typedef struct {
 } hm2_pwmgen_instance_t;
 
 
-// these hal params affect all pwmgen instances
+// these hal pins affect all pwmgen instances
 typedef struct {
     struct {
-        hal_u32_t pwm_frequency;
-        hal_u32_t pdm_frequency;
-    } param;
+        hal_u32_t *pwm_frequency;
+        hal_u32_t *pdm_frequency;
+    } pin;
 } hm2_pwmgen_module_global_t;
 
 
@@ -594,7 +583,7 @@ typedef struct {
     // module-global HAL objects...
     hm2_pwmgen_module_global_t *hal;
 
-    // these keep track of the most recent hal->param.p{d,w}m_frequency
+    // these keep track of the most recent hal->pin.p{d,w}m_frequency
     // that we've told the FPGA about, so we know if we need to update it
     u32 written_pwm_frequency;
     u32 written_pdm_frequency;
@@ -668,7 +657,7 @@ typedef struct {
     u32 clock_frequency;
     u8 version;
 
-    // these keep track of the most recent hal->param.p{d,w}m_frequency
+    // these keep track of the most recent hal->pin.p{d,w}m_frequency
     // that we've told the FPGA about, so we know if we need to update it
     u32 written_pwm_frequency;
 
@@ -784,7 +773,7 @@ typedef struct {
 } hm2_stepgen_instance_t;
 
 
-// these hal params affect all stepgen instances
+// these hal pins affect all stepgen instances
 typedef struct {
     struct {
         hal_s32_t *dpll_timer_num;
@@ -1141,7 +1130,7 @@ typedef struct {
 
 } hm2_capsense_instance_t;
 
-// these hal params affect all pwmgen instances
+// these hal pins affect all pwmgen instances
 typedef struct {
     struct {
         hal_u32_t *capsense_hysteresis;
@@ -1152,7 +1141,7 @@ typedef struct {
     int num_instances;
     hm2_capsense_instance_t *instance;
 
-    // these keep track of the most recent hal->param.p{d,w}m_frequency
+    // these keep track of the most recent hal->pin.p{d,w}m_frequency
     // that we've told the FPGA about, so we know if we need to update it
     u32 written_capsense_hysteresis_reg;
 

--- a/src/hal/drivers/mesa-hostmot2/ioport.c
+++ b/src/hal/drivers/mesa-hostmot2/ioport.c
@@ -258,34 +258,34 @@ int hm2_ioport_gpio_export_hal(hostmot2_t *hm2) {
             || (hm2->pin[i].direction == HM2_PIN_DIR_IS_OUTPUT)
         ) {
 
-            r = hal_param_bit_newf(
-                HAL_RW,
-                &(hm2->pin[i].instance->hal.param.invert_output),
+            r = hal_pin_bit_newf(
+                HAL_IO,
+                &(hm2->pin[i].instance->hal.pin.invert_output),
                 hm2->llio->comp_id,
                 "%s.gpio.%03d.invert_output",
                 hm2->llio->name,
                 i
             );
             if (r < 0) {
-                HM2_ERR("error %d adding gpio param, aborting\n", r);
+                HM2_ERR("error %d adding gpio pin, aborting\n", r);
                 return -EINVAL;
             }
 
-            r = hal_param_bit_newf(
-                HAL_RW,
-                &(hm2->pin[i].instance->hal.param.is_opendrain),
+            r = hal_pin_bit_newf(
+                HAL_IO,
+                &(hm2->pin[i].instance->hal.pin.is_opendrain),
                 hm2->llio->comp_id,
                 "%s.gpio.%03d.is_opendrain",
                 hm2->llio->name,
                 i
             );
             if (r < 0) {
-                HM2_ERR("error %d adding gpio param, aborting\n", r);
+                HM2_ERR("error %d adding gpio pin, aborting\n", r);
                 return -EINVAL;
             }
 
-            hm2->pin[i].instance->hal.param.invert_output = 0;
-            hm2->pin[i].instance->hal.param.is_opendrain = 0;
+            *hm2->pin[i].instance->hal.pin.invert_output = 0;
+            *hm2->pin[i].instance->hal.pin.is_opendrain = 0;
         }
 
 
@@ -311,20 +311,20 @@ int hm2_ioport_gpio_export_hal(hostmot2_t *hm2) {
             *(hm2->pin[i].instance->hal.pin.out) = 0;
 
             // parameters
-            r = hal_param_bit_newf(
-                HAL_RW,
-                &(hm2->pin[i].instance->hal.param.is_output),
+            r = hal_pin_bit_newf(
+                HAL_IO,
+                &(hm2->pin[i].instance->hal.pin.is_output),
                 hm2->llio->comp_id,
                 "%s.gpio.%03d.is_output",
                 hm2->llio->name,
                 i
             );
             if (r < 0) {
-                HM2_ERR("error %d adding gpio param, aborting\n", r);
+                HM2_ERR("error %d adding gpio pin, aborting\n", r);
                 return -EINVAL;
             }
 
-            hm2->pin[i].instance->hal.param.is_output = 0;
+            *(hm2->pin[i].instance->hal.pin.is_output) = 0;
         }
     }
 
@@ -389,7 +389,7 @@ void hm2_ioport_update(hostmot2_t *hm2) {
             int io_pin = (port * hm2->idrom.port_width) + port_pin;
 
             if (hm2->pin[io_pin].gtag == HM2_GTAG_IOPORT) {
-                if (hm2->pin[io_pin].instance->hal.param.is_output) {
+                if (*(hm2->pin[io_pin].instance->hal.pin.is_output)) {
                     hm2->pin[io_pin].direction = HM2_PIN_DIR_IS_OUTPUT;
                 } else {
                     hm2->pin[io_pin].direction = HM2_PIN_DIR_IS_INPUT;
@@ -400,14 +400,14 @@ void hm2_ioport_update(hostmot2_t *hm2) {
                 hm2->ioport.ddr_reg[port] |= (1 << port_pin);  // set the bit in the ddr register
 
                 // Open Drain Register
-                if (hm2->pin[io_pin].instance->hal.param.is_opendrain) {
+                if (*(hm2->pin[io_pin].instance->hal.pin.is_opendrain)) {
                     hm2->ioport.open_drain_reg[port] |= (1 << port_pin);  // set the bit in the open drain register
                 } else {
                     hm2->ioport.open_drain_reg[port] &= ~(1 << port_pin);  // clear the bit in the open drain register
                 }
 
                 // Invert Output Register
-                if (hm2->pin[io_pin].instance->hal.param.invert_output) {
+                if (*(hm2->pin[io_pin].instance->hal.pin.invert_output)) {
                     hm2->ioport.output_invert_reg[port] |= (1 << port_pin);  // set the bit in the output invert register
                 } else {
                     hm2->ioport.output_invert_reg[port] &= ~(1 << port_pin);  // clear the bit in the output invert register

--- a/src/hal/drivers/mesa-hostmot2/pwmgen.c
+++ b/src/hal/drivers/mesa-hostmot2/pwmgen.c
@@ -35,14 +35,14 @@ void hm2_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     u32 dds;
 
 
-    if (hm2->pwmgen.hal->param.pwm_frequency < 1) {
-        HM2_ERR("pwmgen.pwm_frequency %d is too low, setting to 1\n", hm2->pwmgen.hal->param.pwm_frequency);
-        hm2->pwmgen.hal->param.pwm_frequency = 1;
+    if (*hm2->pwmgen.hal->pin.pwm_frequency < 1) {
+        HM2_ERR("pwmgen.pwm_frequency %d is too low, setting to 1\n", *hm2->pwmgen.hal->pin.pwm_frequency);
+        *(hm2->pwmgen.hal->pin.pwm_frequency) = 1;
     }
 
 
     // 
-    // hal->param.pwm_frequency is the user's desired PWM frequency in Hz
+    // hal->pin.pwm_frequency is the user's desired PWM frequency in Hz
     //
     // We get to play with PWMClock (frequency at which the PWM counter
     // runs) and PWMBits (number of bits of the PWM Value Register that
@@ -66,7 +66,7 @@ void hm2_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     //
 
     // can we do it with 12 bits?
-    dds = ((double)hm2->pwmgen.hal->param.pwm_frequency * 65536.0 * 4096.0) / (double)hm2->pwmgen.clock_frequency;
+    dds = ((double)(*hm2->pwmgen.hal->pin.pwm_frequency) * 65536.0 * 4096.0) / (double)hm2->pwmgen.clock_frequency;
     if (dds < 65536) {
         hm2->pwmgen.pwmgen_master_rate_dds_reg = dds;
         hm2->pwmgen.pwm_bits = 12;
@@ -74,7 +74,7 @@ void hm2_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     }
 
     // try 11 bits
-    dds = ((double)hm2->pwmgen.hal->param.pwm_frequency * 65536.0 * 2048.0) / (double)hm2->pwmgen.clock_frequency;
+    dds = ((double)(*hm2->pwmgen.hal->pin.pwm_frequency) * 65536.0 * 2048.0) / (double)hm2->pwmgen.clock_frequency;
     if (dds < 65536) {
         hm2->pwmgen.pwmgen_master_rate_dds_reg = dds;
         hm2->pwmgen.pwm_bits = 11;
@@ -82,7 +82,7 @@ void hm2_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     }
 
     // try 10 bits
-    dds = ((double)hm2->pwmgen.hal->param.pwm_frequency * 65536.0 * 1024.0) / (double)hm2->pwmgen.clock_frequency;
+    dds = ((double)(*hm2->pwmgen.hal->pin.pwm_frequency) * 65536.0 * 1024.0) / (double)hm2->pwmgen.clock_frequency;
     if (dds < 65536) {
         hm2->pwmgen.pwmgen_master_rate_dds_reg = dds;
         hm2->pwmgen.pwm_bits = 10;
@@ -90,7 +90,7 @@ void hm2_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     }
 
     // try 9 bits
-    dds = ((double)hm2->pwmgen.hal->param.pwm_frequency * 65536.0 * 512.0) / (double)hm2->pwmgen.clock_frequency;
+    dds = ((double)(*hm2->pwmgen.hal->pin.pwm_frequency) * 65536.0 * 512.0) / (double)hm2->pwmgen.clock_frequency;
     if (dds < 65536) {
         hm2->pwmgen.pwmgen_master_rate_dds_reg = dds;
         hm2->pwmgen.pwm_bits = 9;
@@ -100,8 +100,8 @@ void hm2_pwmgen_handle_pwm_frequency(hostmot2_t *hm2) {
     // no joy, lower frequency until it'll work with 9 bits
     // From above:
     //     PWMFreq = (ClockHigh * DDS) / (65536 * 2^PWMBits)
-    hm2->pwmgen.hal->param.pwm_frequency = ((double)hm2->pwmgen.clock_frequency * 65535.0) / (65536.0 * 512.0);
-    HM2_ERR("max PWM frequency is %d Hz\n", hm2->pwmgen.hal->param.pwm_frequency);
+    *(hm2->pwmgen.hal->pin.pwm_frequency) = ((double)hm2->pwmgen.clock_frequency * 65535.0) / (65536.0 * 512.0);
+    HM2_ERR("max PWM frequency is %d Hz\n", *hm2->pwmgen.hal->pin.pwm_frequency);
     hm2->pwmgen.pwmgen_master_rate_dds_reg = 65535;
     hm2->pwmgen.pwm_bits = 9;
 }
@@ -111,14 +111,14 @@ void hm2_pwmgen_handle_pdm_frequency(hostmot2_t *hm2) {
     u32 dds;
 
 
-    if (hm2->pwmgen.hal->param.pdm_frequency < 1) {
-        HM2_ERR("pwmgen.pdm_frequency %d is too low, setting to 1\n", hm2->pwmgen.hal->param.pdm_frequency);
-        hm2->pwmgen.hal->param.pdm_frequency = 1;
+    if (*hm2->pwmgen.hal->pin.pdm_frequency < 1) {
+        HM2_ERR("pwmgen.pdm_frequency %d is too low, setting to 1\n", *hm2->pwmgen.hal->pin.pdm_frequency);
+        *(hm2->pwmgen.hal->pin.pdm_frequency) = 1;
     }
 
 
     // 
-    // hal->param.pdm_frequency is the user's desired PDM frequency in Hz
+    // hal->pin.pdm_frequency is the user's desired PDM frequency in Hz
     //
     // We get to play with PDMClock (frequency at which the PDM counter
     // runs) only - PDMBits (number of bits of the PDM Value Register that
@@ -152,14 +152,14 @@ void hm2_pwmgen_handle_pdm_frequency(hostmot2_t *hm2) {
     //
 
     // can we do it with 12 bits?
-    dds = ((double)hm2->pwmgen.hal->param.pdm_frequency * 65536.0) / (double)hm2->pwmgen.clock_frequency;
+    dds = ((double)(*hm2->pwmgen.hal->pin.pdm_frequency) * 65536.0) / (double)hm2->pwmgen.clock_frequency;
     if (dds == 0) {
         // too slow, set frequency to minimum
         // From above:
         //     PulseFreq = (ClockHigh * DDS) / 65536
         dds = 1;
-        hm2->pwmgen.hal->param.pdm_frequency = ((double)hm2->pwmgen.clock_frequency * (double)dds) / 65536.0;
-        HM2_ERR("min PDM frequency is %d Hz\n", hm2->pwmgen.hal->param.pdm_frequency);
+        *(hm2->pwmgen.hal->pin.pdm_frequency) = ((double)hm2->pwmgen.clock_frequency * (double)dds) / 65536.0;
+        HM2_ERR("min PDM frequency is %d Hz\n", *hm2->pwmgen.hal->pin.pdm_frequency);
         hm2->pwmgen.pdmgen_master_rate_dds_reg = 1;
         return;
     }
@@ -173,8 +173,8 @@ void hm2_pwmgen_handle_pdm_frequency(hostmot2_t *hm2) {
     // user wants too much, lower frequency until it'll work with 12 bits
     // From above:
     //     PulseFreq = (ClockHigh * DDS) / 65536
-    hm2->pwmgen.hal->param.pdm_frequency = ((double)hm2->pwmgen.clock_frequency * 65535.0) / 65536.0;
-    HM2_ERR("max PDM frequency is %d Hz\n", hm2->pwmgen.hal->param.pdm_frequency);
+    *(hm2->pwmgen.hal->pin.pdm_frequency) = ((double)hm2->pwmgen.clock_frequency * 65535.0) / 65536.0;
+    HM2_ERR("max PDM frequency is %d Hz\n", *hm2->pwmgen.hal->pin.pdm_frequency);
     hm2->pwmgen.pdmgen_master_rate_dds_reg = 65535;
 }
 
@@ -220,7 +220,7 @@ void hm2_pwmgen_force_write(hostmot2_t *hm2) {
 
         hm2->pwmgen.pwm_mode_reg[i] = pwm_width;
 
-        switch (hm2->pwmgen.instance[i].hal.param.output_type) {
+        switch (*hm2->pwmgen.instance[i].hal.pin.output_type) {
             case HM2_PWMGEN_OUTPUT_TYPE_PWM: {
                 // leave the Output Mode bits 0
                 double_buffered = 1;
@@ -248,7 +248,7 @@ void hm2_pwmgen_force_write(hostmot2_t *hm2) {
             default: {  // unknown pwm mode!  complain and switch to pwm/dir
                 HM2_ERR(
                     "invalid pwmgen output_type %d requested\n",
-                    hm2->pwmgen.instance[i].hal.param.output_type
+                    *hm2->pwmgen.instance[i].hal.pin.output_type
                 ); 
                 HM2_ERR(
                     "supported .output-type values are: %d (PWM & Dir), %d (Up & Down), %d (PDM & Dir), and %d (Dir & PWM)\n",
@@ -258,7 +258,7 @@ void hm2_pwmgen_force_write(hostmot2_t *hm2) {
                     HM2_PWMGEN_OUTPUT_TYPE_PWM_SWAPPED
                 ); 
                 HM2_ERR("switching to 1 (PWM & Dir)\n"); 
-                hm2->pwmgen.instance[i].hal.param.output_type = HM2_PWMGEN_OUTPUT_TYPE_PWM;
+                *(hm2->pwmgen.instance[i].hal.pin.output_type) = HM2_PWMGEN_OUTPUT_TYPE_PWM;
                 double_buffered = 1;
                 // leave the Output Mode bits 0
                 break;
@@ -286,12 +286,12 @@ void hm2_pwmgen_force_write(hostmot2_t *hm2) {
     if ((*hm2->llio->io_error) != 0) return;
 
     for (i = 0; i < hm2->pwmgen.num_instances; i ++) {
-        hm2->pwmgen.instance[i].written_output_type = hm2->pwmgen.instance[i].hal.param.output_type;
+        hm2->pwmgen.instance[i].written_output_type = *hm2->pwmgen.instance[i].hal.pin.output_type;
         hm2->pwmgen.instance[i].written_enable = *hm2->pwmgen.instance[i].hal.pin.enable;
     }
 
-    hm2->pwmgen.written_pwm_frequency = hm2->pwmgen.hal->param.pwm_frequency;
-    hm2->pwmgen.written_pdm_frequency = hm2->pwmgen.hal->param.pdm_frequency;
+    hm2->pwmgen.written_pwm_frequency = *hm2->pwmgen.hal->pin.pwm_frequency;
+    hm2->pwmgen.written_pdm_frequency = *hm2->pwmgen.hal->pin.pdm_frequency;
 }
 
 
@@ -308,14 +308,14 @@ void hm2_pwmgen_write(hostmot2_t *hm2) {
 
     // check output type
     for (i = 0; i < hm2->pwmgen.num_instances; i ++) {
-        if (hm2->pwmgen.instance[i].hal.param.output_type != hm2->pwmgen.instance[i].written_output_type) {
+        if (*hm2->pwmgen.instance[i].hal.pin.output_type != hm2->pwmgen.instance[i].written_output_type) {
             goto force_write;
         }
     }
 
     // check pwm & pdm frequency
-    if (hm2->pwmgen.hal->param.pwm_frequency != hm2->pwmgen.written_pwm_frequency) goto force_write;
-    if (hm2->pwmgen.hal->param.pdm_frequency != hm2->pwmgen.written_pdm_frequency) goto force_write;
+    if (*hm2->pwmgen.hal->pin.pwm_frequency != hm2->pwmgen.written_pwm_frequency) goto force_write;
+    if (*hm2->pwmgen.hal->pin.pdm_frequency != hm2->pwmgen.written_pdm_frequency) goto force_write;
 
     // update enable register?
     for (i = 0; i < hm2->pwmgen.num_instances; i ++) {
@@ -428,32 +428,32 @@ int hm2_pwmgen_parse_md(hostmot2_t *hm2, int md_index) {
 
 
         // these hal parameters affect all pwmgen instances
-        r = hal_param_u32_newf(
-            HAL_RW,
-            &(hm2->pwmgen.hal->param.pwm_frequency),
+        r = hal_pin_u32_newf(
+            HAL_IO,
+            &(hm2->pwmgen.hal->pin.pwm_frequency),
             hm2->llio->comp_id,
             "%s.pwmgen.pwm_frequency",
             hm2->llio->name
         );
         if (r < 0) {
-            HM2_ERR("error adding pwmgen.pwm_frequency param, aborting\n");
+            HM2_ERR("error adding pwmgen.pwm_frequency pin, aborting\n");
             goto fail1;
         }
-        hm2->pwmgen.hal->param.pwm_frequency = 20000;
+        *(hm2->pwmgen.hal->pin.pwm_frequency) = 20000;
         hm2->pwmgen.written_pwm_frequency = 0;
 
-        r = hal_param_u32_newf(
-            HAL_RW,
-            &(hm2->pwmgen.hal->param.pdm_frequency),
+        r = hal_pin_u32_newf(
+            HAL_IO,
+            &(hm2->pwmgen.hal->pin.pdm_frequency),
             hm2->llio->comp_id,
             "%s.pwmgen.pdm_frequency",
             hm2->llio->name
         );
         if (r < 0) {
-            HM2_ERR("error adding pwmgen.pdm_frequency param, aborting\n");
+            HM2_ERR("error adding pwmgen.pdm_frequency pin, aborting\n");
             goto fail1;
         }
-        hm2->pwmgen.hal->param.pdm_frequency = 20000;
+        *(hm2->pwmgen.hal->pin.pdm_frequency) = 20000;
         hm2->pwmgen.written_pdm_frequency = 0;
 
 
@@ -476,30 +476,30 @@ int hm2_pwmgen_parse_md(hostmot2_t *hm2, int md_index) {
             // parameters
 
             rtapi_snprintf(name, sizeof(name), "%s.pwmgen.%02d.scale", hm2->llio->name, i);
-            r = hal_param_float_new(name, HAL_RW, &(hm2->pwmgen.instance[i].hal.param.scale), hm2->llio->comp_id);
+            r = hal_pin_float_new(name, HAL_IO, &(hm2->pwmgen.instance[i].hal.pin.scale), hm2->llio->comp_id);
             if (r < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
             }
 
-            r = hal_param_s32_newf(
-                HAL_RW,
-                &(hm2->pwmgen.instance[i].hal.param.output_type),
+            r = hal_pin_s32_newf(
+                HAL_IO,
+                &(hm2->pwmgen.instance[i].hal.pin.output_type),
                 hm2->llio->comp_id,
                 "%s.pwmgen.%02d.output-type",
                 hm2->llio->name,
                 i
             );
             if (r < 0) {
-                HM2_ERR("error adding param, aborting\n");
+                HM2_ERR("error adding pin, aborting\n");
                 goto fail1;
             }
 
             // init hal objects
             *(hm2->pwmgen.instance[i].hal.pin.enable) = 0;
             *(hm2->pwmgen.instance[i].hal.pin.value) = 0.0;
-            hm2->pwmgen.instance[i].hal.param.scale = 1.0;
-            hm2->pwmgen.instance[i].hal.param.output_type = HM2_PWMGEN_OUTPUT_TYPE_PWM;
+            *(hm2->pwmgen.instance[i].hal.pin.scale) = 1.0;
+            *(hm2->pwmgen.instance[i].hal.pin.output_type) = HM2_PWMGEN_OUTPUT_TYPE_PWM;
 
             hm2->pwmgen.instance[i].written_output_type = -666;  // force an update at the start
             hm2->pwmgen.instance[i].written_enable = -666;       // force an update at the start
@@ -585,13 +585,13 @@ void hm2_pwmgen_prepare_tram_write(hostmot2_t *hm2) {
             continue;
         }
 
-        scaled_value = *hm2->pwmgen.instance[i].hal.pin.value / hm2->pwmgen.instance[i].hal.param.scale;
+        scaled_value = *hm2->pwmgen.instance[i].hal.pin.value / *hm2->pwmgen.instance[i].hal.pin.scale;
 
         abs_duty_cycle = rtapi_fabs(scaled_value);
         if (abs_duty_cycle > 1.0) abs_duty_cycle = 1.0;
 
         // duty_cycle goes from 0.0 to 1.0, and needs to be puffed out to pwm_bits (if it's pwm) or 12 (if it's pdm)
-        if (hm2->pwmgen.instance[i].hal.param.output_type == HM2_PWMGEN_OUTPUT_TYPE_PDM) {
+        if (*hm2->pwmgen.instance[i].hal.pin.output_type == HM2_PWMGEN_OUTPUT_TYPE_PDM) {
             bits = 12;
         } else {
             bits = hm2->pwmgen.pwm_bits;

--- a/src/hal/drivers/mesa-hostmot2/resolver.c
+++ b/src/hal/drivers/mesa-hostmot2/resolver.c
@@ -149,11 +149,11 @@ int hm2_resolver_parse_md(hostmot2_t *hm2, int md_index) {
         
         rtapi_snprintf(name, sizeof(name), "%s.resolver.excitation-khz", 
                        hm2->llio->name);
-        ret= hal_param_float_new(name, HAL_RW, 
-                                 &(hm2->resolver.hal->param.excitation_khz), 
+        ret= hal_pin_float_new(name, HAL_IO,
+                                 &(hm2->resolver.hal->pin.excitation_khz),
                                  hm2->llio->comp_id);
         if (ret < 0) {
-            HM2_ERR("error adding param '%s', aborting\n", name);
+            HM2_ERR("error adding pin '%s', aborting\n", name);
             goto fail1;
         }
         
@@ -244,31 +244,31 @@ int hm2_resolver_parse_md(hostmot2_t *hm2, int md_index) {
             // parameters
             rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.scale", 
                            hm2->llio->name, i);
-            ret= hal_param_float_new(name, HAL_RW, 
-                                     &(hm2->resolver.instance[i].hal.param.scale), 
+            ret= hal_pin_float_new(name, HAL_IO,
+                                     &(hm2->resolver.instance[i].hal.pin.scale),
                                      hm2->llio->comp_id);
             if (ret < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
             }
             
             rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.velocity-scale", 
                            hm2->llio->name, i);
-            ret= hal_param_float_new(name, HAL_RW, 
-                                     &(hm2->resolver.instance[i].hal.param.vel_scale), 
+            ret= hal_pin_float_new(name, HAL_IO,
+                                     &(hm2->resolver.instance[i].hal.pin.vel_scale),
                                      hm2->llio->comp_id);
             if (ret < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
             }
 
             rtapi_snprintf(name, sizeof(name), "%s.resolver.%02d.index-divisor",
                            hm2->llio->name, i);
-            ret= hal_param_u32_new(name, HAL_RW,
-                                     &(hm2->resolver.instance[i].hal.param.index_div),
+            ret= hal_pin_u32_new(name, HAL_IO,
+                                     &(hm2->resolver.instance[i].hal.pin.index_div),
                                      hm2->llio->comp_id);
             if (ret < 0) {
-                HM2_ERR("error adding param '%s', aborting\n", name);
+                HM2_ERR("error adding pin '%s', aborting\n", name);
                 goto fail1;
             }
 
@@ -278,10 +278,10 @@ int hm2_resolver_parse_md(hostmot2_t *hm2, int md_index) {
             //
             
             *hm2->resolver.instance[i].hal.pin.reset = 0;
-            hm2->resolver.instance[i].hal.param.scale = 1.0;
-            hm2->resolver.instance[i].hal.param.vel_scale = 1.0;
-            hm2->resolver.instance[i].hal.param.index_div = 1;
-            hm2->resolver.hal->param.excitation_khz = -1; // don't-write
+            *hm2->resolver.instance[i].hal.pin.scale = 1.0;
+            *hm2->resolver.instance[i].hal.pin.vel_scale = 1.0;
+            *hm2->resolver.instance[i].hal.pin.index_div = 1;
+            *hm2->resolver.hal->pin.excitation_khz = -1; // don't-write
             hm2->resolver.kHz = (hm2->resolver.clock_frequency / 5000);
         }
     }
@@ -310,13 +310,13 @@ void hm2_resolver_process_tram_read(hostmot2_t *hm2, long period) {
         res = &hm2->resolver.instance[i];
         
         // sanity check
-        if (res->hal.param.scale == 0.0) {
+        if (*res->hal.pin.scale == 0.0) {
             HM2_ERR("resolver.%02d.scale == 0.0, bogus, setting to 1.0\n", i);
-            res->hal.param.scale = 1.0;
+            *(res->hal.pin.scale) = 1.0;
         }
-        if (res->hal.param.vel_scale == 0.0) {
+        if (*res->hal.pin.vel_scale == 0.0) {
             HM2_ERR("resolver.%02d.velocity-scale == 0.0, bogus, setting to 1.0\n", i);
-            res->hal.param.vel_scale = 1.0;
+            *(res->hal.pin.vel_scale) = 1.0;
         }
         
         // PROCESS THE REGISTERS, SET THE PINS
@@ -326,9 +326,9 @@ void hm2_resolver_process_tram_read(hostmot2_t *hm2, long period) {
         if ((res->old_reg > hm2->resolver.position_reg[i]) && (res->old_reg - hm2->resolver.position_reg[i] > 0x80000000)){
             res->index_cnts++;
             if (*res->hal.pin.index_enable){
-                int r = (res->index_cnts % res->hal.param.index_div);
-                if ((res->hal.param.index_div  > 1 && r == 1) 
-                 || (res->hal.param.index_div == 1 && r == 0)){
+                int r = (res->index_cnts % *res->hal.pin.index_div);
+                if ((*res->hal.pin.index_div  > 1 && r == 1)
+                 || (*res->hal.pin.index_div == 1 && r == 0)){
                     res->offset = (res->accum - hm2->resolver.position_reg[i]);
                     *res->hal.pin.index_enable = 0;
                 }
@@ -336,7 +336,7 @@ void hm2_resolver_process_tram_read(hostmot2_t *hm2, long period) {
         }
         else if ((res->old_reg < hm2->resolver.position_reg[i]) && (hm2->resolver.position_reg[i] - res->old_reg > 0x80000000)){
             res->index_cnts--;
-            if (*res->hal.pin.index_enable && (res->index_cnts % res->hal.param.index_div == 0)){
+            if (*res->hal.pin.index_enable && (res->index_cnts % *res->hal.pin.index_div == 0)){
                 res->offset = (res->accum - hm2->resolver.position_reg[i] + 0x100000000LL);
                 *res->hal.pin.index_enable = 0;
             }
@@ -352,9 +352,9 @@ void hm2_resolver_process_tram_read(hostmot2_t *hm2, long period) {
         *res->hal.pin.rawcounts = (res->accum >> 8);
         *res->hal.pin.count = (res->accum - res->offset) >> 8;
         *res->hal.pin.position = (res->accum - res->offset) / 4294967296.0
-                                 * res->hal.param.scale;
+                                 * *res->hal.pin.scale;
         *res->hal.pin.velocity = ((hm2->resolver.velocity_reg[i] / 4294967296.0)
-                                  * hm2->resolver.kHz * res->hal.param.vel_scale);
+                                  * hm2->resolver.kHz * *res->hal.pin.vel_scale);
         *res->hal.pin.error = *hm2->resolver.status_reg & (1 << i);
     }
 }
@@ -370,22 +370,22 @@ void hm2_resolver_write(hostmot2_t *hm2, long period){
     
     switch (state){
         case 0: // Idle/waiting
-            if (hm2->resolver.hal->param.excitation_khz < 0){
+            if (*hm2->resolver.hal->pin.excitation_khz < 0){
                 return;
             }
-            if (hm2->resolver.hal->param.excitation_khz != hm2->resolver.written_khz){
-                if (hm2->resolver.hal->param.excitation_khz > 8){
-                    hm2->resolver.hal->param.excitation_khz = 10;
+            if (*hm2->resolver.hal->pin.excitation_khz != hm2->resolver.written_khz){
+                if (*hm2->resolver.hal->pin.excitation_khz > 8){
+                    *(hm2->resolver.hal->pin.excitation_khz) = 10;
                     hm2->resolver.written_khz = 10;
                     hm2->resolver.kHz = (hm2->resolver.clock_frequency / 5000);
                     cmd_val = 0x803;
-                } else if (hm2->resolver.hal->param.excitation_khz > 4){
-                    hm2->resolver.hal->param.excitation_khz = 5;
+                } else if (*hm2->resolver.hal->pin.excitation_khz > 4){
+                    *(hm2->resolver.hal->pin.excitation_khz) = 5;
                     hm2->resolver.written_khz = 5;
                     hm2->resolver.kHz = (hm2->resolver.clock_frequency / 10000);
                     cmd_val = 0x802;
                 }else{
-                    hm2->resolver.hal->param.excitation_khz = 2.5;
+                    *(hm2->resolver.hal->pin.excitation_khz) = 2.5;
                     hm2->resolver.written_khz = 2.5;
                     hm2->resolver.kHz= (hm2->resolver.clock_frequency / 20000);
                     cmd_val = 0x801;
@@ -395,7 +395,7 @@ void hm2_resolver_write(hostmot2_t *hm2, long period){
                 return;
             }
             break;
-        case 10: // wait for comand register clear before setting params
+        case 10: // wait for command register clear before setting pins
             hm2->llio->read(hm2->llio,hm2->resolver.command_addr, 
                             &buff, sizeof(u32));
             if (buff){
@@ -413,7 +413,7 @@ void hm2_resolver_write(hostmot2_t *hm2, long period){
             state = 20;
             timer = 0;
             return;
-        case 20: // wait for command to clear before processing any more params
+        case 20: // wait for command to clear before processing any more pins
             hm2->llio->read(hm2->llio,hm2->resolver.command_addr, 
                             &buff, sizeof(u32));
             if (buff){


### PR DESCRIPTION
HAL params are deprecated and can't be used from the Python HAL API. This patch converts all hm2 HAL param to HAL pins.

From non-Python API the usage doesn't change, `setp` still works.