### PR TITLE
Implementation of setting environment variables in Github Actions with new interface

### DIFF
--- a/.github/workflows/debian-builder-workflow.yaml
+++ b/.github/workflows/debian-builder-workflow.yaml
@@ -138,7 +138,7 @@ jobs:
                              " exist in registry $DOCKER_BASE_ADDRESS"  \
                              "/$IMAGE_PREFIX\n")
             echo "::warning::$WARNING"
-            echo "::set-env name=BuildDockerImage::true"
+            echo "BuildDockerImage=true" >> $GITHUB_ENV
             printf "Going to force rebuild of all Docker images!\n"
             exit 0
           fi
@@ -183,7 +183,7 @@ jobs:
                            "============================================\n" \
                            "$DOCKER_GIT_TABLE\n")
           echo "::warning::$WARNING"
-          echo "::set-env name=BuildDockerImage::true"
+          echo "BuildDockerImage=true" >> $GITHUB_ENV
           printf "Going to force rebuild of all Docker images!\n"
           exit 0
         fi
@@ -212,7 +212,7 @@ jobs:
                  "Git commit $GIT_COMMIT_SHA from which the current cached" \
                  " Docker images were built cannot be found in history.\n"  \
                  "Going to force rebuild of all Docker images!\n"
-          echo "::set-env name=BuildDockerImage::true"
+          echo "BuildDockerImage=true" >> $GITHUB_ENV
         fi
       env:
         GIT_COMMIT_SHA: ${{ steps.docker_metadata_normalizer.outputs.git_sha }}
@@ -233,7 +233,7 @@ jobs:
             printf "%b"                                               \
                    "Found file $line matching the regular expression" \
                    " for Debian builder files.\n"
-            echo "::set-env name=BuildDockerImage::true"
+            echo "BuildDockerImage=true" >> $GITHUB_ENV
             exit 0
           fi
         done <<< "$CHANGED_FILES"
@@ -379,7 +379,7 @@ jobs:
           in paths
         run: |
           DISTRIBUTION_LOWER=$(echo "$DISTRIBUTION" | awk '{print tolower($0)}')
-          echo "::set-env name=distribution_normalized::$DISTRIBUTION_LOWER"
+          echo "distribution_normalized=$DISTRIBUTION_LOWER" >> $GITHUB_ENV
         env:
           DISTRIBUTION: ${{ matrix.osDistribution}}
 

--- a/.github/workflows/debian-builder-workflow.yaml
+++ b/.github/workflows/debian-builder-workflow.yaml
@@ -610,9 +610,6 @@ jobs:
       - name: Execute CMOCKA UNIT tests
         run: printf "Not yet implemented\n"
 
-      - name: Execute Python nosetests
-        run: printf "Not yet implemented\n"
-
   # This has a chance to cause problems when developing multiple branches 
   # simultaneously all or some of which use different builder configuration,
   # one way how to solve it is to use different tags for different branches, 


### PR DESCRIPTION
This pull request implements:

- Github Actions API deprecated calls to `set-env` because of security bug ([blog post](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/), which was the reason why workflow runs have been recently failing
- New way of setting environment variables are the so-called [**Environment files**](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files)

(Problem reported in #331.)