### PR TITLE
Set CAP_SYS_NICE for Docker containers in CI runs

### DIFF
--- a/.github/workflows/debian-builder-workflow.yaml
+++ b/.github/workflows/debian-builder-workflow.yaml
@@ -598,10 +598,11 @@ jobs:
 
       - name: Execute Runtests
         run: |
-          docker run --tty --rm -u "$(id -u):$(id -g)" \
+          docker run --tty --rm -u "$(id -u):$(id -g)"        \
             -v "$(pwd):/home/machinekit/build/machinekit-hal" \
-            -w "/home/machinekit/build/machinekit-hal" \
-            ${DOCKER_IMAGE} \
+            -w "/home/machinekit/build/machinekit-hal"        \
+            --cap-add=sys_nice                                \
+            ${DOCKER_IMAGE}                                   \
             debian/ripruntests.py
         env:
           DOCKER_IMAGE: 'docker.pkg.github.com/${{ github.repository }}/${{ matrix.dockerImage.basename }}:latest'

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@
 
 sudo: required
 
-dist: bionic
+dist: focal
+group: edge
 
 notifications:
   email:
@@ -64,26 +65,30 @@ matrix:
       arch: amd64
       env: ARCHITECTURE=amd64 VERSION=20.04 DISTRIBUTION=ubuntu
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       env: ARCHITECTURE=arm64 VERSION=20.04 DISTRIBUTION=ubuntu
+      virt: vm
     - os: linux
       arch: amd64
       env: ARCHITECTURE=amd64 VERSION=10 DISTRIBUTION=debian
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       env: ARCHITECTURE=arm64 VERSION=10 DISTRIBUTION=debian
+      virt: vm
     - os: linux
       arch: amd64
       env: ARCHITECTURE=amd64 VERSION=18.04 DISTRIBUTION=ubuntu
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       env: ARCHITECTURE=arm64 VERSION=18.04 DISTRIBUTION=ubuntu
+      virt: vm
     - os: linux
       arch: amd64
       env: ARCHITECTURE=amd64 VERSION=9 DISTRIBUTION=debian
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       env: ARCHITECTURE=arm64 VERSION=9 DISTRIBUTION=debian
+      virt: vm
     - os: linux
       arch: amd64
       env: ARCHITECTURE=armhf VERSION=20.04 DISTRIBUTION=ubuntu
@@ -184,23 +189,24 @@ script:
     PARENT_DIR="$(dirname ${LOCAL_DIR})";
     DOCKER_IMAGE="machinekit-hal-${DISTRIBUTION}-builder-v.${ARCHITECTURE}_${VERSION}:latest";
     docker run --tty --rm -u "$(id -u):$(id -g)" \
-      -v "${PARENT_DIR}:/home/machinekit/build" \
+      -v "${PARENT_DIR}:/home/machinekit/build"  \
       -w "/home/machinekit/build/machinekit-hal" \
       ${DOCKER_IMAGE} debian/bootstrap &&
     docker run --tty --rm -u "$(id -u):$(id -g)" \
-      -v "${PARENT_DIR}:/home/machinekit/build" \
+      -v "${PARENT_DIR}:/home/machinekit/build"  \
       -w "/home/machinekit/build/machinekit-hal" \
       ${DOCKER_IMAGE} debian/configure.py -c &&
     docker run --tty --rm -u "$(id -u):$(id -g)" \
-      -v "${PARENT_DIR}:/home/machinekit/build" \
+      -v "${PARENT_DIR}:/home/machinekit/build"  \
       -w "/home/machinekit/build/machinekit-hal" \
       ${DOCKER_IMAGE} debian/buildpackages.py &&
     if [[ "$ARCHITECTURE" == "$TRAVIS_CPU_ARCH" ]];
     then
       git -C ${LOCAL_DIR} clean -xdf &&
       docker run --tty --rm -u "$(id -u):$(id -g)" \
-        -v "${PARENT_DIR}:/home/machinekit/build" \
+        -v "${PARENT_DIR}:/home/machinekit/build"  \
         -w "/home/machinekit/build/machinekit-hal" \
+        --cap-add=sys_nice                         \
         ${DOCKER_IMAGE} debian/ripruntests.py; 
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,32 +123,41 @@ matrix:
       arch: amd64
       env: ARCHITECTURE=arm64 VERSION=9 DISTRIBUTION=debian
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       env: ARCHITECTURE=armhf VERSION=20.04 DISTRIBUTION=ubuntu
+      virt: lxd
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       env: ARCHITECTURE=amd64 VERSION=20.04 DISTRIBUTION=ubuntu
+      virt: lxd
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       env: ARCHITECTURE=armhf VERSION=10 DISTRIBUTION=debian
+      virt: lxd
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       env: ARCHITECTURE=amd64 VERSION=10 DISTRIBUTION=debian
+      virt: lxd
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       env: ARCHITECTURE=i386 VERSION=10 DISTRIBUTION=debian
+      virt: lxd
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       env: ARCHITECTURE=armhf VERSION=18.04 DISTRIBUTION=ubuntu
+      virt: lxd
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       env: ARCHITECTURE=amd64 VERSION=18.04 DISTRIBUTION=ubuntu
+      virt: lxd
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       env: ARCHITECTURE=i386 VERSION=18.04 DISTRIBUTION=ubuntu
+      virt: lxd
     - os: linux
-      arch: arm64
+      arch: arm64-graviton2
       env: ARCHITECTURE=armhf VERSION=9 DISTRIBUTION=debian
+      virt: lxd
     # Tests
     # - Reduce total build time by starting longest jobs first
     #- ARCHITECTURE=amd64 VERSION=10   CMD=test


### PR DESCRIPTION
This pull request implements:

- Transfer Travis CI `arm64` to **Graviton2** based servers - full _Virtual Machines_ for running tests and _LXD_ for cross-building
- Run the `ripruntests.py` script in container with `CAP_SYS_NICE`

(_BTW, the Graviton2 servers are really nice. Building and testing Machinekit-HAL is quicker there than on `amd64` servers, I kid you not._)

This should solve the **thread.0** issues for time being on Travis. (On Drone they can still occur.)