### PR TITLE
Python3: fix configparser letter case in 4 files

### DIFF
--- a/src/hal/icomp-example/lutn-demo.py
+++ b/src/hal/icomp-example/lutn-demo.py
@@ -7,7 +7,7 @@ from machinekit.nosetests.realtime import setup_module,teardown_module
 
 setup_module()
 
-cfg = ConfigParser.ConfigParser()
+cfg = configparser.ConfigParser()
 cfg.read(os.getenv("MACHINEKIT_INI"))
 uuid = cfg.get("MACHINEKIT", "MKUUID")
 rt = rtapi.RTAPIcommand(uuid=uuid)

--- a/src/hal/user_comps/hal_storage.py
+++ b/src/hal/user_comps/hal_storage.py
@@ -11,7 +11,7 @@ import sys
 import os
 import argparse
 
-import ConfigParser
+import configparser
 
 import hal
 
@@ -64,7 +64,7 @@ if not os.path.isfile(filename):
     sys.stderr.write('Error: File does not exist.\n')
     sys.exit(1)
 
-cfg = ConfigParser.ConfigParser()
+cfg = configparser.ConfigParser()
 cfg.read(filename)
 h = hal.component(args.name)
 for section in cfg.sections():

--- a/src/machinetalk/tutorial/json-ws/micromot-server.py
+++ b/src/machinetalk/tutorial/json-ws/micromot-server.py
@@ -3,7 +3,7 @@ import os,time,sys
 import zmq
 import time
 import sys
-import ConfigParser
+import configparser
 import subprocess
 from machinekit import rtapi,hal
 
@@ -22,7 +22,7 @@ def multiframe_ring(name):
 subprocess.call("realtime restart", shell=True,stderr=subprocess.STDOUT)
 
 # connect to RTAPI
-cfg = ConfigParser.ConfigParser()
+cfg = configparser.ConfigParser()
 cfg.read(os.getenv("MACHINEKIT_INI"))
 uuid = cfg.get("MACHINEKIT", "MKUUID")
 rt = rtapi.RTAPIcommand(uuid=uuid)

--- a/src/machinetalk/tutorial/zeroconf/resolve.py
+++ b/src/machinetalk/tutorial/zeroconf/resolve.py
@@ -10,7 +10,7 @@ from dbus.mainloop.glib import DBusGMainLoop
 import avahi
 import gobject
 import threading
-import ConfigParser
+import configparser
 
 gobject.threads_init()
 dbus.mainloop.glib.threads_init()
@@ -118,7 +118,7 @@ def main():
         print >> sys.stderr, "no MACHINEKIT_INI environment variable set"
         sys.exit(1)
 
-    mki = ConfigParser.ConfigParser()
+    mki = configparser.ConfigParser()
     mki.read(mkini)
     uuid = mki.get("MACHINEKIT", "MKUUID")
     remote = mki.getint("MACHINEKIT", "REMOTE")


### PR DESCRIPTION
ConfigParser is renamed to configparser in python3

Signed-off-by: Holotronic <producer@holotronic.dk>