### PR TITLE
fixes for hal_pru_generic pwmread tasklet

### DIFF
--- a/src/hal/drivers/hal_pru_generic/hal_pru_generic.c
+++ b/src/hal/drivers/hal_pru_generic/hal_pru_generic.c
@@ -128,7 +128,7 @@ static int num_encoders = 0;
 RTAPI_MP_INT(num_encoders, "Number of encoder channels (default: 0)");
 
 static int num_pwmreads = 0;
-RTAPI_MP_INT(num_pwmreads, "Number of PWM read channels (default: 0)");
+RTAPI_IP_INT(num_pwmreads, "Number of PWM read channels (default: 0)");
 
 static char *halname = "hal_pru_generic";
 RTAPI_MP_STRING(halname, "Prefix for hal names (default: hal_pru_generic)");

--- a/src/hal/drivers/hal_pru_generic/pru_pwmread.p
+++ b/src/hal/drivers/hal_pru_generic/pru_pwmread.p
@@ -80,13 +80,13 @@ CHECK_MAX_TIME:
 // zero lo
     LDI State.LoTime, 0
     MOV State.HiTime, State.MaxTime
-    LDI State.CurTime, 0
+    MOV State.CurTime, State.MaxTime
     JMP PWM_READ_DONE
 
 ZERO_HI:
     MOV State.LoTime, State.MaxTime
     LDI State.HiTime, 0
-    LDI State.CurTime, 0
+    MOV State.CurTime, State.MaxTime
 
 PWM_READ_DONE:
     

--- a/src/hal/drivers/hal_pru_generic/pwmread.c
+++ b/src/hal/drivers/hal_pru_generic/pwmread.c
@@ -65,7 +65,14 @@ void hpg_pwmread_read(hal_pru_generic_t *hpg) {
       PRU_task_pwmread_t *pru = (PRU_task_pwmread_t*)((u32)hpg->pru_data+(u32)hpg->pwmread.instance[i].task.addr);
       const u32 hiTime = pru->hiTime;
       const u32 loTime = pru->loTime;
-      const u32 period = hiTime+loTime;
+      const u32 maxTime = pru->maxTime;
+
+      u32 period = hiTime+loTime;
+
+      if(period > maxTime) {
+        period = maxTime;
+      }
+
       const float frequency = 1.0f/((float)period/1e9);
       const float duty_cycle = (float)(hiTime)/period;
 


### PR DESCRIPTION
fixed issues where long high or low pulses reset the current time
which occasionally results in reporting a very short high or low
pulse (resulting in misrepresenting the period/frequency of
the PWM signal for a half cycle)
SOFT-553