### PR TITLE
Resolve licensing issues around the Readline library

### DIFF
--- a/debian/bootstrap
+++ b/debian/bootstrap
@@ -172,6 +172,39 @@ search_for_xenomai() {
     return 0
 }
 
+search_for_readline(){
+    local library="$(apt-cache search libeditreadline-dev)"
+    local retval="$?" 
+    if ((retval != 0 ))
+    then
+        log_error "Command 'apt-cache search libeditreadline-dev' returned error code $retval!"
+        return -1
+    fi
+
+    if [[ "$library" =~ ^libeditreadline-dev.* ]]
+    then
+        BUILDTIME_DEPENDENCIES+=", libeditreadline-dev"
+        return 0
+    fi
+
+    local library="$(apt-cache search libreadline-gplv2-dev)"
+    local retval="$?" 
+    if ((retval != 0 ))
+    then
+        log_error "Command 'apt-cache search libreadline-gplv2-dev' returned error code $retval!"
+        return -1
+    fi
+
+    if [[ "$library" =~ ^libreadline-gplv2-dev.* ]]
+    then
+        BUILDTIME_DEPENDENCIES+=", libreadline-gplv2-dev"
+        return 0
+    fi
+
+    log_error "No readline-like development library found!"
+    return -1
+}
+
 test_dir(){
     local version_file="$1/VERSION"
     local readme_file="$1/README.md"
@@ -275,6 +308,12 @@ _main(){
     fi
 
     search_for_xenomai
+    retval=$?
+    if (( retval != 0 ))
+    then
+        failure
+    fi
+    search_for_readline
     retval=$?
     if (( retval != 0 ))
     then

--- a/debian/control.in
+++ b/debian/control.in
@@ -18,7 +18,6 @@ Build-Depends:
     libudev-dev,
     libglib2.0-dev,
     libgtk2.0-dev,
-    libreadline-dev,
     libusb-1.0-0-dev,
     python3:native,
     libpython3-dev,

--- a/src/hal/utils/halcmd_completion.h
+++ b/src/hal/utils/halcmd_completion.h
@@ -40,6 +40,7 @@
 #ifndef HALCMD_COMPLETION_H
 #define HALCMD_COMPLETION_H
 
+#include <ctype.h>
 #include <stdio.h>
 #include <readline/readline.h>
 #include <readline/history.h>


### PR DESCRIPTION
This pull request implements the following functionality:

- PR #351 introduces regression when build started using `libreadline-dev` package which is from licensing standpoint incompatible with code of Machinekit-HAL
- The original `libreadline-gplv2-dev` package is no longer available on Ubuntu 21.04 Hirsute, which is why newly the buildsystem depends on `libeditreadline-dev` where possible and fall back to `libreadline-gplv2-dev` package
- The `libeditreadline-dev` is a GPLv2 conforming wrapper around `libeditline-dev` providing `libreadline-dev` shims to allow straightforward linking (i.e. no change should be needed [not 100% true, but still]).