### PR TITLE
Fix `-Wunused-parameter` warnings

### DIFF
--- a/src/rtapi/rtapi.h.in
+++ b/src/rtapi/rtapi.h.in
@@ -892,6 +892,9 @@ extern rtapi_exception_handler_t  rtapi_set_exception(rtapi_exception_handler_t 
 
     static __inline__ void *rtapi_request_region(unsigned long base,
             unsigned long size, const char *name) {
+        (void)size;
+        (void)base;
+        (void)name;
         return (void*)-1;
     }
 
@@ -902,6 +905,8 @@ extern rtapi_exception_handler_t  rtapi_set_exception(rtapi_exception_handler_t 
 */
     static __inline__ void rtapi_release_region(unsigned long base,
             unsigned long int size) {
+      (void)size;
+      (void)base;
     }
 #endif // RTAPI && BUILD_DRIVERS
 


### PR DESCRIPTION
In file included from /usr/include/machinekit/hal.h:126,
                 from [...]/hal_ros_control/hal_hw_interface/include/hal_hw_interface/hal_ros_logging.hpp:37,
                 from [...]/hal_ros_control/hal_hw_interface/src/hal_control_node.cpp:32:
/usr/include/machinekit/rtapi.h: In function ‘void* rtapi_request_region(long unsigned int, long unsigned int, const char*)’:
/usr/include/machinekit/rtapi.h:894:64: warning: unused parameter ‘base’ [-Wunused-parameter]
  894 |     static __inline__ void *rtapi_request_region(unsigned long base,
      |                                                  ~~~~~~~~~~~~~~^~~~
/usr/include/machinekit/rtapi.h:895:27: warning: unused parameter ‘size’ [-Wunused-parameter]
  895 |             unsigned long size, const char *name) {
      |             ~~~~~~~~~~~~~~^~~~
/usr/include/machinekit/rtapi.h:895:45: warning: unused parameter ‘name’ [-Wunused-parameter]
  895 |             unsigned long size, const char *name) {
      |                                 ~~~~~~~~~~~~^~~~
/usr/include/machinekit/rtapi.h: In function ‘void rtapi_release_region(long unsigned int, long unsigned int)’:
/usr/include/machinekit/rtapi.h:904:63: warning: unused parameter ‘base’ [-Wunused-parameter]
  904 |     static __inline__ void rtapi_release_region(unsigned long base,
      |                                                 ~~~~~~~~~~~~~~^~~~
/usr/include/machinekit/rtapi.h:905:31: warning: unused parameter ‘size’ [-Wunused-parameter]
  905 |             unsigned long int size) {
      |             ~~~~~~~~~~~~~~~~~~^~~~