### PR TITLE
Repair CMake export system for building out-of-tree targets

### DIFF
--- a/src/executables/comp/CMakeLists.txt
+++ b/src/executables/comp/CMakeLists.txt
@@ -148,7 +148,8 @@ if(BUILD_PYTHON_DISTRIBUTIONS)
     configure_file(
       ${CMAKE_CURRENT_SOURCE_DIR}/src/MachinekitHALCompFunction.cmake
       ${MACHINEKIT_HAL_CMAKE_PACKAGE_OUTPUT_DIRECTORY}/MachinekitHALCompFunction.cmake
-      @ONLY NEWLINE_STYLE UNIX NO_SOURCE_PERMISSIONS)
+      @ONLY
+      NEWLINE_STYLE UNIX NO_SOURCE_PERMISSIONS)
 
     set_property(
       GLOBAL PROPERTY MACHINEKIT_HAL_COMP
@@ -157,8 +158,10 @@ if(BUILD_PYTHON_DISTRIBUTIONS)
     install_wheel(WHEEL "${OUTPUT_INDEX}" COMPONENT
                   MachinekitHAL_Executable_Comp_Python_Packages)
 
-    cpack_add_component(MachinekitHAL_Executable_Comp_Python_Packages
-                        GROUP MachinekitHAL_Executable_Comp)
+    cpack_add_component(
+      MachinekitHAL_Executable_Comp_Python_Packages
+      DEPENDS MachinekitHAL_Library_Symbol_Visibility_CMake_Functions
+      GROUP MachinekitHAL_Executable_Comp)
 
     # Specification of artifacts placement in package tree
     cpack_add_component_group(

--- a/src/executables/instcomp/CMakeLists.txt
+++ b/src/executables/instcomp/CMakeLists.txt
@@ -167,8 +167,10 @@ if(BUILD_PYTHON_DISTRIBUTIONS)
     install_wheel(WHEEL "${OUTPUT_INDEX}" COMPONENT
                   MachinekitHAL_Executable_Instcomp_Python_Packages)
 
-    cpack_add_component(MachinekitHAL_Executable_Instcomp_Python_Packages
-                        GROUP MachinekitHAL_Executable_Instcomp)
+    cpack_add_component(
+      MachinekitHAL_Executable_Instcomp_Python_Packages
+      DEPENDS MachinekitHAL_Library_Symbol_Visibility_CMake_Functions
+      GROUP MachinekitHAL_Executable_Instcomp)
 
     # Specification of artifacts placement in package tree
     cpack_add_component_group(

--- a/src/libraries/export_package/src/Machinekit-HALConfig.cmake.in
+++ b/src/libraries/export_package/src/Machinekit-HALConfig.cmake.in
@@ -87,7 +87,7 @@ foreach(_component ${${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS})
   if(NOT MHC_component_name IN_LIST MHC_known_components)
     set(${CMAKE_FIND_PACKAGE_NAME}_FOUND False)
     set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
-        "Unsupported component: ${MHC_component}")
+        "Unsupported component: ${MHC_component_name}")
     return()
   endif()
   foreach(_item RANGE 0 ${MHC_component_length} 1)

--- a/src/libraries/hal_command/CMakeLists.txt
+++ b/src/libraries/hal_command/CMakeLists.txt
@@ -100,6 +100,12 @@ if(BUILD_HAL_COMMAND_LIBRARY)
       COMPONENT MachinekitHAL_Library_HAL_Command_Headers)
 
   install(
+    FILES
+      "${MACHINEKIT_HAL_CMAKE_PACKAGE_OUTPUT_DIRECTORY}/MachinekitHALHAL-CommandComponent.cmake"
+    DESTINATION ${MACHINEKIT_HAL_CMAKE_PACKAGE_DIRECTORY}
+    COMPONENT MachinekitHAL_Library_HAL_Command_Package_Exports)
+
+  install(
     EXPORT machinekit_hal_hal_command
     DESTINATION ${MACHINEKIT_HAL_CMAKE_PACKAGE_DIRECTORY}
     NAMESPACE "${MACHINEKIT_HAL_NAMESPACE}::"

--- a/src/libraries/runtime/cmake/MachinekitHALManaged-RuntimeComponent.cmake.in
+++ b/src/libraries/runtime/cmake/MachinekitHALManaged-RuntimeComponent.cmake.in
@@ -34,10 +34,6 @@ set(MHMRC_targets_paths
         \"file\":\"${CMAKE_CURRENT_LIST_DIR}/MachinekitHALRuntimeConfigTarget.cmake\"
     },
     {
-        \"target\":\"@MACHINEKIT_HAL_NAMESPACE@::rtapi_pci\",
-        \"file\":\"${CMAKE_CURRENT_LIST_DIR}/MachinekitHALRTAPIPCITarget.cmake\"
-    },
-    {
         \"target\":\"@MACHINEKIT_HAL_NAMESPACE@::mkini\",
         \"file\":\"${CMAKE_CURRENT_LIST_DIR}/MachinekitHALMKIniTarget.cmake\"
     },
@@ -48,6 +44,10 @@ set(MHMRC_targets_paths
     {
         \"target\":\"@MACHINEKIT_HAL_NAMESPACE@::runtime_api\",
         \"file\":\"${CMAKE_CURRENT_LIST_DIR}/MachinekitHALRuntimeAPITarget.cmake\"
+    },
+    {
+        \"target\":\"Machinekit::HAL::rtapi_compat\",
+        \"file\":\"${CMAKE_CURRENT_LIST_DIR}/MachinekitHALRuntimeCompatTarget.cmake\"
     },
     {
         \"target\":\"@MACHINEKIT_HAL_NAMESPACE@::managed_runtime\",

--- a/src/libraries/symbol_visibility/CMakeLists.txt
+++ b/src/libraries/symbol_visibility/CMakeLists.txt
@@ -30,12 +30,27 @@ option(BUILD_SYMBOL_VISIBILITY_CMAKE_MODULE
 if(BUILD_SYMBOL_VISIBILITY_CMAKE_MODULE)
 
   set(SOURCE_FILE
-      ${CMAKE_CURRENT_SOURCE_DIR}/src/MachinekitHALSymbolVisibilityFunction.cmake)
+      ${CMAKE_CURRENT_SOURCE_DIR}/src/MachinekitHALSymbolVisibilityFunction.cmake
+  )
 
   configure_file(
     ${SOURCE_FILE}
     "${MACHINEKIT_HAL_CMAKE_PACKAGE_OUTPUT_DIRECTORY}/MachinekitHALSymbolVisibilityFunction.cmake"
     NO_SOURCE_PERMISSIONS
     COPYONLY)
+
+  install(
+    FILES
+      "${MACHINEKIT_HAL_CMAKE_PACKAGE_OUTPUT_DIRECTORY}/MachinekitHALSymbolVisibilityFunction.cmake"
+    DESTINATION "${MACHINEKIT_HAL_CMAKE_PACKAGE_DIRECTORY}"
+    COMPONENT MachinekitHAL_Library_Symbol_Visibility_CMake_Functions)
+
+  cpack_add_component(MachinekitHAL_Library_Symbol_Visibility_CMake_Functions
+                      GROUP MachinekitHAL_Library_Symbol_Visibility_Development)
+
+  # Specification of artifacts placement in package tree
+  cpack_add_component_group(
+    MachinekitHAL_Library_Symbol_Visibility_Development
+    PARENT_GROUP MachinekitHAL_Package_Base_Libraries_Development)
 
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ if(BUILD_RUNTESTS_TESTSUITE)
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-runtime-cmake-component/test.py
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-runtime-cmake-component/test.sh
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-runtime-pci-cmake-component/checkresult
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-runtime-pci-cmake-component/skip
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-runtime-pci-cmake-component/test.py
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-runtime-pci-cmake-component/test.sh
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-hal-cmake-component/checkresult
@@ -66,6 +67,7 @@ if(BUILD_RUNTESTS_TESTSUITE)
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-runtime-cmake-component/test.py
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-runtime-cmake-component/test.sh
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/checkresult
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/skip
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/test.py
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/test.sh
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/counter-encoder.0/expected

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,31 @@ if(BUILD_RUNTESTS_TESTSUITE)
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/basic/expected
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/basic/README
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/basic/test.hal
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/all-cmake-components/checkresult
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/all-cmake-components/test.py
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/all-cmake-components/test.sh
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/cmake_test_helpers.py
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/hal-command-cmake-component/checkresult
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/hal-command-cmake-component/test.py
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/hal-command-cmake-component/test.sh
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-hal-cmake-component/checkresult
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-hal-cmake-component/test.py
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-hal-cmake-component/test.sh
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-runtime-cmake-component/checkresult
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-runtime-cmake-component/test.py
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-runtime-cmake-component/test.sh
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-runtime-pci-cmake-component/checkresult
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-runtime-pci-cmake-component/test.py
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/managed-runtime-pci-cmake-component/test.sh
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-hal-cmake-component/checkresult
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-hal-cmake-component/test.py
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-hal-cmake-component/test.sh
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-runtime-cmake-component/checkresult
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-runtime-cmake-component/test.py
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-runtime-cmake-component/test.sh
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/checkresult
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/test.py
+      ${CMAKE_CURRENT_SOURCE_DIR}/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/test.sh
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/counter-encoder.0/expected
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/counter-encoder.0/README
       ${CMAKE_CURRENT_SOURCE_DIR}/runtests/counter-encoder.0/test.hal

--- a/tests/runtests/cmake-exports/all-cmake-components/checkresult
+++ b/tests/runtests/cmake-exports/all-cmake-components/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0 # test failure is indicated by test.sh exit value

--- a/tests/runtests/cmake-exports/all-cmake-components/test.py
+++ b/tests/runtests/cmake-exports/all-cmake-components/test.py
@@ -25,6 +25,7 @@
 
 import importlib.util
 import pathlib
+import platform
 
 current_directory = pathlib.Path(__file__).resolve().parent
 
@@ -38,20 +39,30 @@ spec.loader.exec_module(helpers)
 def main():
     all_components = ['Managed-Runtime', 'Managed-HAL',
                       'Unmanaged-Runtime', 'Unmanaged-HAL',
-                      'Managed-Runtime-PCI', 'Unmanaged-Runtime-PCI',
                       'HAL-Command']
+    rtapi_pci_component = ['Managed-Runtime-PCI', 'Unmanaged-Runtime-PCI']
     expected_targets = [
         'Machinekit::HAL::managed_runtime',
         'Machinekit::HAL::managed_hal',
         'Machinekit::HAL::unmanaged_runtime',
         'Machinekit::HAL::unmanaged_hal',
+        'Machinekit::HAL::hal_command',
+    ]
+    rtapi_pci_targets = [
         'Machinekit::HAL::unmanaged_rtapi_pci',
         'Machinekit::HAL::managed_rtapi_pci',
-        'Machinekit::HAL::hal_command',
     ]
     unexpected_targets = [
         'Machinekit::HAL::non_existent',
     ]
+    # This is minimal and presumes only the amd64, i686, armhf and arm64
+    # on the Debian based systems and with Python3 installed from packages
+    # Basicaly 'Good Enough' solution for now only!
+    if platform.machine() in ['aarch64', 'armv7l']:
+        unexpected_targets.extend(rtapi_pci_targets)
+    else:
+        expected_targets.extend(rtapi_pci_targets)
+        all_components.extend(rtapi_pci_component)
     expected_commands = [
         'export_rtapi_symbols',
     ]

--- a/tests/runtests/cmake-exports/all-cmake-components/test.py
+++ b/tests/runtests/cmake-exports/all-cmake-components/test.py
@@ -1,0 +1,61 @@
+#####################################################################
+# Description:  test.py
+#
+#               This file, 'test.py', implements a single CMake based
+#               test of extended Machinekit-HAL buildsystem. (Primarily
+#               importing previously exported targets.)
+#
+# Copyright (C) 2022    Jakub Fišer  <jakub DOT fiser AT eryaf DOT com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+######################################################################
+
+import importlib.util
+import pathlib
+
+current_directory = pathlib.Path(__file__).resolve().parent
+
+spec = importlib.util.spec_from_file_location(
+    "cmake_test_helpers",
+    current_directory.parent / 'cmake_test_helpers.py')
+helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helpers)
+
+
+def main():
+    all_components = ['Managed-Runtime', 'Managed-HAL',
+                      'Unmanaged-Runtime', 'Unmanaged-HAL',
+                      'Managed-Runtime-PCI', 'Unmanaged-Runtime-PCI',
+                      'HAL-Command']
+    expected_targets = [
+        'Machinekit::HAL::managed_runtime',
+        'Machinekit::HAL::managed_hal',
+        'Machinekit::HAL::unmanaged_runtime',
+        'Machinekit::HAL::unmanaged_hal',
+        'Machinekit::HAL::unmanaged_rtapi_pci',
+        'Machinekit::HAL::managed_rtapi_pci',
+        'Machinekit::HAL::hal_command',
+    ]
+    unexpected_targets = [
+        'Machinekit::HAL::non_existent',
+    ]
+
+    helpers.verify_cmake_targets(
+        all_components, expected_targets, unexpected_targets, current_directory)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/runtests/cmake-exports/all-cmake-components/test.py
+++ b/tests/runtests/cmake-exports/all-cmake-components/test.py
@@ -52,9 +52,21 @@ def main():
     unexpected_targets = [
         'Machinekit::HAL::non_existent',
     ]
+    expected_commands = [
+        'export_rtapi_symbols',
+    ]
+    unexpected_commands = [
+        'unknown_function',
+        'another_non_existent_function'
+    ]
 
     helpers.verify_cmake_targets(
-        all_components, expected_targets, unexpected_targets, current_directory)
+        all_components,
+        expected_targets,
+        unexpected_targets,
+        expected_commands,
+        unexpected_commands,
+        current_directory)
 
 
 if __name__ == '__main__':

--- a/tests/runtests/cmake-exports/all-cmake-components/test.sh
+++ b/tests/runtests/cmake-exports/all-cmake-components/test.sh
@@ -1,0 +1,4 @@
+PYTHON_INTERPRETER="$(which python3)"
+echo "Using $PYTHON_INTERPRETER as the Python3 interpreter."
+${PYTHON_INTERPRETER} ./test.py
+exit "$?"

--- a/tests/runtests/cmake-exports/cmake_test_helpers.py
+++ b/tests/runtests/cmake-exports/cmake_test_helpers.py
@@ -1,0 +1,141 @@
+#####################################################################
+# Description:  cmake_test_helpers.py
+#
+#               This file, 'cmake_test_helpers.py', implements functions used
+#               for testing CMake export system for Machinekit-HAL for both
+#               in-source and out-of-source building of extension modules,
+#               libraries and executables.
+#
+# Copyright (C) 2022    Jakub Fišer  <jakub DOT fiser AT eryaf DOT com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+######################################################################
+
+import pathlib
+import copy
+import tempfile
+import subprocess
+import re
+
+from typing import List
+
+basic_testing_cmake = """
+cmake_minimum_required(VERSION 3.22)
+
+project(Machinekit-HALRuntestCMake{test_name} LANGUAGES C)
+
+find_package(
+  Machinekit-HAL
+  COMPONENTS {required_components}
+  REQUIRED)
+
+foreach(
+  _target {tested_targets})
+  if(TARGET ${{_target}})
+    message("TARGET ${{_target}} found.")
+  else()
+    message("TARGET ${{_target}} NOT found!")
+  endif()
+endforeach()
+"""
+
+
+def verify_cmake_targets(
+        components: List[str],
+        defined_targets: List[str] = [],
+        undefined_targets: List[str] = [],
+        directory_path: pathlib.Path = None,
+        test_name: str = 'componentTest'
+):
+    if defined_targets is None:
+        defined_targets = []
+    if undefined_targets is None:
+        undefined_targets = []
+
+    required_components = ' '.join(components)
+    tested_targets = ';'.join(defined_targets+undefined_targets)
+    cmake_directory = pathlib.Path(tempfile.mkdtemp(
+        suffix=f'cmake_{test_name}', prefix='mkh_runtest', dir=directory_path))
+
+    cmakefile = basic_testing_cmake.format(
+        test_name=test_name,
+        required_components=required_components,
+        tested_targets=tested_targets)
+
+    with open(cmake_directory / 'CMakeLists.txt', 'w')as f:
+        f.write(cmakefile)
+
+    print(
+        f'Generated CMakeLists.txt file:\n=============\n{cmakefile}\n=============')
+
+    try:
+        cmake_output = (subprocess.check_output(
+            ['cmake',
+             '-S', str(cmake_directory),
+             '-B', str(cmake_directory), ],
+            stderr=subprocess.STDOUT)).decode('utf-8')
+    except subprocess.CalledProcessError as e:
+        print(f'Subprocess call with parameters: {e.cmd}\n'
+              f'returned output:\n{e.output.decode("utf-8") if isinstance(e.output, bytes) else e.output}\n'
+              f'and error output:\n{e.stderr.decode("utf-8") if isinstance(e.stderr, bytes) else e.stderr}\n!!!!!!!!')
+        raise RuntimeError(
+            f'Call to external CMake process failed with return code {e.returncode}!')
+
+    print(
+        f'CMake run output:\n**************\n{cmake_output}\n**************')
+
+    if defined_targets:
+        target_found_regex = re.compile(r'TARGET (?P<target>[\w:]+) found.')
+
+        _available_matches = target_found_regex.findall(cmake_output)
+
+        print(
+            f'Available TARGETS found in the CMake output: {_available_matches}')
+
+        if not _available_matches:
+            raise RuntimeError(
+                f'No matches for regex "{target_found_regex.pattern}" found!')
+
+        leftover_defined_targets = copy.copy(defined_targets)
+        for _match in _available_matches:
+            if _match in leftover_defined_targets:
+                leftover_defined_targets.remove(_match)
+
+        if leftover_defined_targets:
+            raise RuntimeError(
+                f'Defined targets not found: {leftover_defined_targets}')
+
+    if undefined_targets:
+        target_not_found_regex = re.compile(
+            r'TARGET (?P<target>[\w:]+) NOT found!')
+
+        _unavailable_matches = target_not_found_regex.findall(cmake_output)
+
+        print(
+            f'Non-Available TARGETS found in the CMake output: {_unavailable_matches}')
+
+        if not _unavailable_matches:
+            raise RuntimeError(
+                f'No matches for regex "{target_not_found_regex.pattern}" found!')
+
+        leftover_undefined_targets = copy.copy(undefined_targets)
+        for _match in _unavailable_matches:
+            if _match in leftover_undefined_targets:
+                leftover_undefined_targets.remove(_match)
+
+        if leftover_undefined_targets:
+            raise RuntimeError(
+                f'Found targets which should not have been: {leftover_undefined_targets}')

--- a/tests/runtests/cmake-exports/hal-command-cmake-component/checkresult
+++ b/tests/runtests/cmake-exports/hal-command-cmake-component/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0 # test failure is indicated by test.sh exit value

--- a/tests/runtests/cmake-exports/hal-command-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/hal-command-cmake-component/test.py
@@ -1,0 +1,61 @@
+#####################################################################
+# Description:  test.py
+#
+#               This file, 'test.py', implements a single CMake based
+#               test of extended Machinekit-HAL buildsystem. (Primarily
+#               importing previously exported targets.)
+#
+# Copyright (C) 2022    Jakub Fišer  <jakub DOT fiser AT eryaf DOT com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+######################################################################
+
+import importlib.util
+import pathlib
+import sys
+
+current_directory = pathlib.Path(__file__).resolve().parent
+
+spec = importlib.util.spec_from_file_location(
+    "cmake_test_helpers",
+    current_directory.parent / 'cmake_test_helpers.py')
+helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helpers)
+
+
+def main() -> int:
+    all_components = ['HAL-Command']
+    expected_targets = [
+        'Machinekit::HAL::hal_command',
+    ]
+    unexpected_targets = [
+        'Machinekit::HAL::managed_hal',
+        'Machinekit::HAL::managed_runtime',
+    ]
+
+    try:
+        helpers.verify_cmake_targets(
+            all_components, expected_targets, unexpected_targets, current_directory)
+
+    except Exception as e:
+        print(e)
+        return -1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/runtests/cmake-exports/hal-command-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/hal-command-cmake-component/test.py
@@ -48,7 +48,7 @@ def main() -> int:
 
     try:
         helpers.verify_cmake_targets(
-            all_components, expected_targets, unexpected_targets, current_directory)
+            all_components, expected_targets, unexpected_targets, None, None, current_directory)
 
     except Exception as e:
         print(e)

--- a/tests/runtests/cmake-exports/hal-command-cmake-component/test.sh
+++ b/tests/runtests/cmake-exports/hal-command-cmake-component/test.sh
@@ -1,0 +1,4 @@
+PYTHON_INTERPRETER="$(which python3)"
+echo "Using $PYTHON_INTERPRETER as the Python3 interpreter."
+${PYTHON_INTERPRETER} ./test.py
+exit "$?"

--- a/tests/runtests/cmake-exports/managed-hal-cmake-component/checkresult
+++ b/tests/runtests/cmake-exports/managed-hal-cmake-component/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0 # test failure is indicated by test.sh exit value

--- a/tests/runtests/cmake-exports/managed-hal-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/managed-hal-cmake-component/test.py
@@ -44,10 +44,16 @@ def main() -> int:
     unexpected_targets = [
         'Machinekit::HAL::unmanaged_hal',
     ]
+    expected_commands = [
+        'export_rtapi_symbols',
+    ]
+    unexpected_commands = [
+        'unknown_function',
+    ]
 
     try:
         helpers.verify_cmake_targets(
-            all_components, expected_targets, unexpected_targets, current_directory)
+            all_components, expected_targets, unexpected_targets, None, None, current_directory)
 
     except Exception as e:
         print(e)

--- a/tests/runtests/cmake-exports/managed-hal-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/managed-hal-cmake-component/test.py
@@ -1,0 +1,60 @@
+#####################################################################
+# Description:  test.py
+#
+#               This file, 'test.py', implements a single CMake based
+#               test of extended Machinekit-HAL buildsystem. (Primarily
+#               importing previously exported targets.)
+#
+# Copyright (C) 2022    Jakub Fišer  <jakub DOT fiser AT eryaf DOT com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+######################################################################
+
+import importlib.util
+import pathlib
+import sys
+
+current_directory = pathlib.Path(__file__).resolve().parent
+
+spec = importlib.util.spec_from_file_location(
+    "cmake_test_helpers",
+    current_directory.parent / 'cmake_test_helpers.py')
+helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helpers)
+
+
+def main() -> int:
+    all_components = ['Managed-HAL']
+    expected_targets = [
+        'Machinekit::HAL::managed_hal',
+    ]
+    unexpected_targets = [
+        'Machinekit::HAL::unmanaged_hal',
+    ]
+
+    try:
+        helpers.verify_cmake_targets(
+            all_components, expected_targets, unexpected_targets, current_directory)
+
+    except Exception as e:
+        print(e)
+        return -1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/runtests/cmake-exports/managed-hal-cmake-component/test.sh
+++ b/tests/runtests/cmake-exports/managed-hal-cmake-component/test.sh
@@ -1,0 +1,4 @@
+PYTHON_INTERPRETER="$(which python3)"
+echo "Using $PYTHON_INTERPRETER as the Python3 interpreter."
+${PYTHON_INTERPRETER} ./test.py
+exit "$?"

--- a/tests/runtests/cmake-exports/managed-runtime-cmake-component/checkresult
+++ b/tests/runtests/cmake-exports/managed-runtime-cmake-component/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0 # test failure is indicated by test.sh exit value

--- a/tests/runtests/cmake-exports/managed-runtime-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/managed-runtime-cmake-component/test.py
@@ -1,0 +1,54 @@
+#####################################################################
+# Description:  test.py
+#
+#               This file, 'test.py', implements a single CMake based
+#               test of extended Machinekit-HAL buildsystem. (Primarily
+#               importing previously exported targets.)
+#
+# Copyright (C) 2022    Jakub Fišer  <jakub DOT fiser AT eryaf DOT com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+######################################################################
+
+import importlib.util
+import pathlib
+
+current_directory = pathlib.Path(__file__).resolve().parent
+
+spec = importlib.util.spec_from_file_location(
+    "cmake_test_helpers",
+    current_directory.parent / 'cmake_test_helpers.py')
+helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helpers)
+
+
+def main():
+    all_components = ['Managed-Runtime']
+    expected_targets = [
+        'Machinekit::HAL::managed_runtime',
+    ]
+    unexpected_targets = [
+        'Machinekit::HAL::unmanaged_hal',
+        'Machinekit::HAL::unmanaged_runtime',
+        'Machinekit::HAL::managed_hal',
+    ]
+
+    helpers.verify_cmake_targets(
+        all_components, expected_targets, unexpected_targets, current_directory)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/runtests/cmake-exports/managed-runtime-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/managed-runtime-cmake-component/test.py
@@ -45,9 +45,20 @@ def main():
         'Machinekit::HAL::unmanaged_runtime',
         'Machinekit::HAL::managed_hal',
     ]
+    expected_commands = [
+        'export_rtapi_symbols',
+    ]
+    unexpected_commands = [
+        'unknown_function',
+    ]
 
     helpers.verify_cmake_targets(
-        all_components, expected_targets, unexpected_targets, current_directory)
+        all_components,
+        expected_targets,
+        unexpected_targets,
+        expected_commands,
+        unexpected_commands,
+        current_directory)
 
 
 if __name__ == '__main__':

--- a/tests/runtests/cmake-exports/managed-runtime-cmake-component/test.sh
+++ b/tests/runtests/cmake-exports/managed-runtime-cmake-component/test.sh
@@ -1,0 +1,4 @@
+PYTHON_INTERPRETER="$(which python3)"
+echo "Using $PYTHON_INTERPRETER as the Python3 interpreter."
+${PYTHON_INTERPRETER} ./test.py
+exit "$?"

--- a/tests/runtests/cmake-exports/managed-runtime-pci-cmake-component/checkresult
+++ b/tests/runtests/cmake-exports/managed-runtime-pci-cmake-component/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0 # test failure is indicated by test.sh exit value

--- a/tests/runtests/cmake-exports/managed-runtime-pci-cmake-component/skip
+++ b/tests/runtests/cmake-exports/managed-runtime-pci-cmake-component/skip
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ -n "$(find /usr -type f -iwholename '*/sys/io.h')" ]]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/tests/runtests/cmake-exports/managed-runtime-pci-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/managed-runtime-pci-cmake-component/test.py
@@ -1,0 +1,60 @@
+#####################################################################
+# Description:  test.py
+#
+#               This file, 'test.py', implements a single CMake based
+#               test of extended Machinekit-HAL buildsystem. (Primarily
+#               importing previously exported targets.)
+#
+# Copyright (C) 2022    Jakub Fišer  <jakub DOT fiser AT eryaf DOT com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+######################################################################
+
+import importlib.util
+import pathlib
+import sys
+
+current_directory = pathlib.Path(__file__).resolve().parent
+
+spec = importlib.util.spec_from_file_location(
+    "cmake_test_helpers",
+    current_directory.parent / 'cmake_test_helpers.py')
+helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helpers)
+
+
+def main() -> int:
+    all_components = ['Managed-Runtime-PCI']
+    expected_targets = [
+        'Machinekit::HAL::managed_rtapi_pci',
+    ]
+    unexpected_targets = [
+        'Machinekit::HAL::unmanaged_rtapi_pci',
+    ]
+
+    try:
+        helpers.verify_cmake_targets(
+            all_components, expected_targets, unexpected_targets, current_directory)
+
+    except Exception as e:
+        print(e)
+        return -1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/runtests/cmake-exports/managed-runtime-pci-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/managed-runtime-pci-cmake-component/test.py
@@ -47,7 +47,7 @@ def main() -> int:
 
     try:
         helpers.verify_cmake_targets(
-            all_components, expected_targets, unexpected_targets, current_directory)
+            all_components, expected_targets, unexpected_targets, None, None, current_directory)
 
     except Exception as e:
         print(e)

--- a/tests/runtests/cmake-exports/managed-runtime-pci-cmake-component/test.sh
+++ b/tests/runtests/cmake-exports/managed-runtime-pci-cmake-component/test.sh
@@ -1,0 +1,4 @@
+PYTHON_INTERPRETER="$(which python3)"
+echo "Using $PYTHON_INTERPRETER as the Python3 interpreter."
+${PYTHON_INTERPRETER} ./test.py
+exit "$?"

--- a/tests/runtests/cmake-exports/unmanaged-hal-cmake-component/checkresult
+++ b/tests/runtests/cmake-exports/unmanaged-hal-cmake-component/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0 # test failure is indicated by test.sh exit value

--- a/tests/runtests/cmake-exports/unmanaged-hal-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/unmanaged-hal-cmake-component/test.py
@@ -47,7 +47,7 @@ def main() -> int:
 
     try:
         helpers.verify_cmake_targets(
-            all_components, expected_targets, unexpected_targets, current_directory)
+            all_components, expected_targets, unexpected_targets, None, None, current_directory)
 
     except Exception as e:
         print(e)

--- a/tests/runtests/cmake-exports/unmanaged-hal-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/unmanaged-hal-cmake-component/test.py
@@ -1,0 +1,60 @@
+#####################################################################
+# Description:  test.py
+#
+#               This file, 'test.py', implements a single CMake based
+#               test of extended Machinekit-HAL buildsystem. (Primarily
+#               importing previously exported targets.)
+#
+# Copyright (C) 2022    Jakub Fišer  <jakub DOT fiser AT eryaf DOT com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+######################################################################
+
+import importlib.util
+import pathlib
+import sys
+
+current_directory = pathlib.Path(__file__).resolve().parent
+
+spec = importlib.util.spec_from_file_location(
+    "cmake_test_helpers",
+    current_directory.parent / 'cmake_test_helpers.py')
+helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helpers)
+
+
+def main() -> int:
+    all_components = ['Unmanaged-HAL']
+    expected_targets = [
+        'Machinekit::HAL::unmanaged_hal',
+    ]
+    unexpected_targets = [
+        'Machinekit::HAL::managed_hal',
+    ]
+
+    try:
+        helpers.verify_cmake_targets(
+            all_components, expected_targets, unexpected_targets, current_directory)
+
+    except Exception as e:
+        print(e)
+        return -1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/runtests/cmake-exports/unmanaged-hal-cmake-component/test.sh
+++ b/tests/runtests/cmake-exports/unmanaged-hal-cmake-component/test.sh
@@ -1,0 +1,4 @@
+PYTHON_INTERPRETER="$(which python3)"
+echo "Using $PYTHON_INTERPRETER as the Python3 interpreter."
+${PYTHON_INTERPRETER} ./test.py
+exit "$?"

--- a/tests/runtests/cmake-exports/unmanaged-runtime-cmake-component/checkresult
+++ b/tests/runtests/cmake-exports/unmanaged-runtime-cmake-component/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0 # test failure is indicated by test.sh exit value

--- a/tests/runtests/cmake-exports/unmanaged-runtime-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/unmanaged-runtime-cmake-component/test.py
@@ -1,0 +1,61 @@
+#####################################################################
+# Description:  test.py
+#
+#               This file, 'test.py', implements a single CMake based
+#               test of extended Machinekit-HAL buildsystem. (Primarily
+#               importing previously exported targets.)
+#
+# Copyright (C) 2022    Jakub Fišer  <jakub DOT fiser AT eryaf DOT com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+######################################################################
+
+import importlib.util
+import pathlib
+import sys
+
+current_directory = pathlib.Path(__file__).resolve().parent
+
+spec = importlib.util.spec_from_file_location(
+    "cmake_test_helpers",
+    current_directory.parent / 'cmake_test_helpers.py')
+helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helpers)
+
+
+def main() -> int:
+    all_components = ['Unmanaged-Runtime']
+    expected_targets = [
+        'Machinekit::HAL::unmanaged_runtime',
+    ]
+    unexpected_targets = [
+        'Machinekit::HAL::managed_runtime',
+        'Machinekit::HAL::managed_hal',
+    ]
+
+    try:
+        helpers.verify_cmake_targets(
+            all_components, expected_targets, unexpected_targets, current_directory)
+
+    except Exception as e:
+        print(e)
+        return -1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/runtests/cmake-exports/unmanaged-runtime-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/unmanaged-runtime-cmake-component/test.py
@@ -48,7 +48,7 @@ def main() -> int:
 
     try:
         helpers.verify_cmake_targets(
-            all_components, expected_targets, unexpected_targets, current_directory)
+            all_components, expected_targets, unexpected_targets, None, None, current_directory)
 
     except Exception as e:
         print(e)

--- a/tests/runtests/cmake-exports/unmanaged-runtime-cmake-component/test.sh
+++ b/tests/runtests/cmake-exports/unmanaged-runtime-cmake-component/test.sh
@@ -1,0 +1,4 @@
+PYTHON_INTERPRETER="$(which python3)"
+echo "Using $PYTHON_INTERPRETER as the Python3 interpreter."
+${PYTHON_INTERPRETER} ./test.py
+exit "$?"

--- a/tests/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/checkresult
+++ b/tests/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0 # test failure is indicated by test.sh exit value

--- a/tests/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/skip
+++ b/tests/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/skip
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ -n "$(find /usr -type f -iwholename '*/sys/io.h')" ]]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/tests/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/test.py
@@ -1,0 +1,60 @@
+#####################################################################
+# Description:  test.py
+#
+#               This file, 'test.py', implements a single CMake based
+#               test of extended Machinekit-HAL buildsystem. (Primarily
+#               importing previously exported targets.)
+#
+# Copyright (C) 2022    Jakub Fišer  <jakub DOT fiser AT eryaf DOT com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+######################################################################
+
+import importlib.util
+import pathlib
+import sys
+
+current_directory = pathlib.Path(__file__).resolve().parent
+
+spec = importlib.util.spec_from_file_location(
+    "cmake_test_helpers",
+    current_directory.parent / 'cmake_test_helpers.py')
+helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helpers)
+
+
+def main() -> int:
+    all_components = ['Unmanaged-Runtime-PCI']
+    expected_targets = [
+        'Machinekit::HAL::unmanaged_rtapi_pci',
+    ]
+    unexpected_targets = [
+        'Machinekit::HAL::managed_rtapi_pci',
+    ]
+
+    try:
+        helpers.verify_cmake_targets(
+            all_components, expected_targets, unexpected_targets, current_directory)
+
+    except Exception as e:
+        print(e)
+        return -1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/test.py
+++ b/tests/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/test.py
@@ -47,7 +47,7 @@ def main() -> int:
 
     try:
         helpers.verify_cmake_targets(
-            all_components, expected_targets, unexpected_targets, current_directory)
+            all_components, expected_targets, unexpected_targets, None, None, current_directory)
 
     except Exception as e:
         print(e)

--- a/tests/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/test.sh
+++ b/tests/runtests/cmake-exports/unmanaged-runtime-pci-cmake-component/test.sh
@@ -1,0 +1,4 @@
+PYTHON_INTERPRETER="$(which python3)"
+echo "Using $PYTHON_INTERPRETER as the Python3 interpreter."
+${PYTHON_INTERPRETER} ./test.py
+exit "$?"


### PR DESCRIPTION
This pull request implements a repair to #349 pull request for the Machinekit-HAL's CMake based export system for building _out-of-tree_ modules, libraries and executables. (Targets which are not build during the bulk of Machinekit-HAL build, but build based on installed Machinekit-HAL [or from BINARY tree].)