### PR TITLE
Mirror GitHub Actions logic for arm64 via Circle CI

### DIFF
--- a/.circleci/base.yaml
+++ b/.circleci/base.yaml
@@ -1,0 +1,329 @@
+#####################################################################
+# Description:  base.yaml
+#
+#               This file, 'base.yaml', implements the base parts used
+#               for dynamic configuration for Circle CI/CD workflow
+#               service for Machinekit-HAL code source-tree.
+#
+# Copyright (C) 2022 -     Jakub Fišer <jakub DOT fiser AT eryaf DOT com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+######################################################################
+
+version: 2.1
+
+# TODO: How to merge keys and override inside elements?
+distribution_name: &distribution_name
+  description: |
+    Name of the Debian-like distribution to use as target
+  type: string
+
+distribution_version: &distribution_version
+  description: |
+    Version of the distribution release to use as target
+  type: string
+
+target_architecture: &target_architecture
+  description: |
+    Target architecture for which to build the builder
+  type: string
+
+image_target: &image_target
+  description: Dockerfile target which to build
+  type: string
+  default: ''
+
+image_name: &image_name
+  description: Pertinent docker image name
+  type: string
+  default: ''
+
+working_directory: &working_directory
+  description: Directory to mount in the container
+  type: string
+
+repository_path: &repository_path
+  description: Path to the Machinekit-HAL repository root
+  type: string
+
+label: &label
+  description: Description to show in the webapp
+  type: string
+
+executor: &executor
+  description: Machine executor class to run the job in
+  type: string
+
+executors:
+  basic-arm64:
+    machine:
+      image: ubuntu-2004:202201-01
+      #docker_layer_caching: true   # Seems like too expensive option
+                                    # per run with limited storage time
+                                    # (The cost for DLC is higher than
+                                    # the cost of building the image
+                                    # on per run basis)
+    resource_class: arm.medium
+    working_directory: ~/run
+  basic-amd64:
+    machine:
+      image: ubuntu-2004:202201-01
+      #docker_layer_caching: true   # Seems like too expensive option
+                                    # per run with limited storage time
+                                    # (The cost for DLC is higher than
+                                    # the cost of building the image
+                                    # on per run basis)
+    resource_class: medium
+    working_directory: ~/run
+
+commands:
+  identify-runner:
+    description: Identify hardware of the CI runner
+    steps:
+      - run:
+          name: Identify hardware of the CI runner
+          command: uname -a
+  install-sh:
+    description: Install the SH Python package
+    steps:
+      - run:
+          name: Install the SH Python package
+          command: python3 -m pip install sh
+  build-mkhb-image:
+    description: Build Machinekit-HAL builder Docker image
+    parameters:
+      distribution_name:
+        <<: *distribution_name
+      distribution_version:
+        <<: *distribution_version
+      target_architecture:
+        <<: *target_architecture
+      image_target:
+        <<: *image_target
+      image_name:
+        <<: *image_name
+      repository_path:
+        <<: *repository_path
+
+      label:
+        <<: *label
+        default: >
+          Building the Machinekit-HAL builder image << parameters.image_target >>
+          for targeting << parameters.distribution_name >>, << parameters.distribution_version >>
+          on << parameters.target_architecture >> with name << parameters.image_name >>
+    steps:
+      - run:
+          name: << parameters.label >>
+          command: |
+            image_target=''
+            image_name=''
+            if [[ '<< parameters.image_target >>' != '' ]]
+            then
+              image_target='-t << parameters.image_target >>'
+            fi
+            if [[ '<< parameters.image_name >>' != '' ]]
+            then
+              image_name='-d << parameters.image_name >>'
+            fi
+            ./debian/buildcontainerimage.py                                    \
+            << parameters.distribution_name >>                                 \
+            << parameters.distribution_version >>                              \
+            << parameters.target_architecture >> ${image_target} ${image_name}
+          working_directory: << parameters.repository_path >>
+  run-in-mkhb-container:
+    description: Run command in Machinekit-HAL builder container
+    parameters:
+      image_name:
+        <<: *image_name
+      working_directory:
+        <<: *working_directory
+      command:
+        description: Command to run in the Docker container
+        type: string
+      capabilities:
+        description: >
+          List of capabilities delimited by a comma which the container
+          should have
+        type: string
+        default: ''
+      label:
+        <<: *label
+        default: >
+          Execute command '<< parameters.command >>' in container
+          created from image << parameters.image_name >>
+    steps:
+      - run:
+          name: << parameters.label >>
+          command: |
+            docker_capabilities=''
+            if [[ '<< parameters.capabilities >>' != '' ]]
+            then
+              docker_capabilities='--cap-add=<< parameters.capabilities >>'
+            fi
+            docker run --tty --rm -u "$(id -u):$(id -g)"         \
+            -v "$(pwd):/home/machinekit/run"                     \
+            -w "/home/machinekit/run"                            \
+            ${docker_capabilities}                               \
+            << parameters.image_name >> << parameters.command >>
+          working_directory: << parameters.working_directory >>
+  prepare-debian-artifacts:
+    description:
+    parameters:
+      repository_path:
+        <<: *repository_path
+      output_directory:
+        description: >
+          Directory path where the prepared Debian packages should
+          be copied to
+        type: string
+    steps:
+      - run:
+          name: Prepare build artifact for upload
+          command: |
+            mkdir -p << parameters.output_directory >>
+            find $(pwd) -maxdepth 1 -mindepth 1 -type f -not \(                                           \
+            -path "." -or -path '$(pwd)' -or -path '$(pwd)/<< parameters.repository_path >>' \) -print0 | \
+            xargs -0 -t -I '{}' cp -r -v '{}'                                                             \
+            << parameters.output_directory >>
+          working_directory: << parameters.repository_path >>/..
+
+
+jobs:
+  buildMachinekitHALPackages:
+    executor: << parameters.executor >>
+    parameters:
+      executor:
+        <<: *executor
+      distribution_name:
+        <<: *distribution_name
+      distribution_version:
+        <<: *distribution_version
+      target_architecture:
+        <<: *target_architecture
+    steps:
+      - identify-runner
+      - checkout:
+          path: machinekit-hal
+      - install-sh
+      - build-mkhb-image:
+          repository_path: machinekit-hal
+          distribution_name: << parameters.distribution_name >>
+          distribution_version: << parameters.distribution_version >>
+          target_architecture: << parameters.target_architecture >>
+          image_name: machinekit-hal-builder:latest
+      - run-in-mkhb-container:
+          label: Bootstrap Machinekit-HAL repository
+          command: debian/bootstrap
+          working_directory: machinekit-hal
+          image_name: machinekit-hal-builder:latest
+      - run-in-mkhb-container:
+          label: Configure Machinekit-HAL repository
+          command: debian/configure.py -c
+          working_directory: machinekit-hal
+          image_name: machinekit-hal-builder:latest
+      - run-in-mkhb-container:
+          label: Build Debian packages from Machinekit-HAL repository
+          command: machinekit-hal/debian/buildpackages.py --path ./machinekit-hal
+          image_name: machinekit-hal-builder:latest
+          working_directory: '.'
+      - prepare-debian-artifacts:
+          repository_path: machinekit-hal
+          output_directory: ~/storage/machinekit-hal-packages-<< parameters.distribution_name >>-<< parameters.distribution_version >>-<< parameters.target_architecture >>
+      - persist_to_workspace:
+          root: ~/storage
+          paths:
+            - machinekit-hal-packages-<< parameters.distribution_name >>-<< parameters.distribution_version >>-<< parameters.target_architecture >>
+      - store_artifacts:
+          path: ~/storage/machinekit-hal-packages-<< parameters.distribution_name >>-<< parameters.distribution_version >>-<< parameters.target_architecture >>
+          destination: machinekit-hal-packages-<< parameters.distribution_name >>-<< parameters.distribution_version >>-<< parameters.target_architecture >>
+
+  testMachinekitHALPackages:
+    executor: << parameters.executor >>
+    parameters:
+      executor:
+        <<: *executor
+      distribution_name:
+        <<: *distribution_name
+      distribution_version:
+        <<: *distribution_version
+      target_architecture:
+        <<: *target_architecture
+    steps:
+      - identify-runner
+      - checkout:
+          path: machinekit-hal
+      - attach_workspace:
+          at: ~/storage
+      - install-sh
+      - build-mkhb-image:
+          label: >
+            Build the runner for installing Machinekit-HAL and run runtests
+            for << parameters.distribution_name >> << parameters.distribution_version >>
+            << parameters.target_architecture >>
+          distribution_name: << parameters.distribution_name >>
+          distribution_version: << parameters.distribution_version >>
+          target_architecture: << parameters.target_architecture >>
+          image_name: machinekit-hal-runner
+          image_target: machinekit-hal_builder_base
+          repository_path: machinekit-hal
+      - run-in-mkhb-container:
+          label: >
+            Install Machinekit-HAL << parameters.distribution_name >> package for
+            << parameters.distribution_version >>, << parameters.target_architecture >> and
+            run Runtests
+          command: |
+            /bin/bash -c "
+              #!/bin/bash -e
+              sudo apt-get install -y  ./*.deb
+              echo "ANNOUNCE_IPV4=0" | sudo tee -a /etc/machinekit/hal/machinekit.ini
+              echo "ANNOUNCE_IPV6=0" | sudo tee -a /etc/machinekit/hal/machinekit.ini
+              run_runtests -v
+            "
+          image_name: machinekit-hal-runner
+          capabilities: sys_nice
+          working_directory: ~/storage/machinekit-hal-packages-<< parameters.distribution_name >>-<< parameters.distribution_version >>-<< parameters.target_architecture >>
+
+  buildDebianVersionAndRunTestsuites:
+    executor: << parameters.executor >>
+    parameters:
+      executor:
+        <<: *executor
+      distribution_name:
+        <<: *distribution_name
+      distribution_version:
+        <<: *distribution_version
+      target_architecture:
+        <<: *target_architecture
+    steps:
+      - identify-runner
+      - checkout:
+          path: machinekit-hal
+      - install-sh
+      - build-mkhb-image:
+          repository_path: machinekit-hal
+          distribution_name: << parameters.distribution_name >>
+          distribution_version: << parameters.distribution_version >>
+          target_architecture: << parameters.target_architecture >>
+          image_name: machinekit-hal-builder:latest
+      - run-in-mkhb-container:
+            label: >
+              Execute the Machinekit-HAL testing suites for << parameters.distribution_name >>
+              << parameters.distribution_version >>, << parameters.target_architecture >>
+            command: |
+              debian/runtests.py -p . -b ./build -g N -c Debug Release RelWithDebInfo
+            image_name: machinekit-hal-builder:latest
+            capabilities: sys_nice
+            working_directory: machinekit-hal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,59 @@
+#####################################################################
+# Description:  config.yml
+#
+#               This file, 'config.yml', implements the CI/CD workflow
+#               for Circle CI service for Machinekit-HAL code source-tree.
+#
+# Copyright (C) 2022 -     Jakub Fišer <jakub DOT fiser AT eryaf DOT com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+######################################################################
+
 version: 2.1
-jobs:
-  build:
+
+# Allows using the Circle CI Dynamic configuration feature
+setup: true
+
+executors:
+  basic-python:
     docker:
-      - image: debian:buster
+      - image: 'cimg/python:3.9.10'
+    working_directory: ~/run
+
+orbs:
+  continuation: circleci/continuation@0.1.2
+
+jobs:
+  setup-build:
+    executor: basic-python
     steps:
-      - checkout
-      - run: echo "Machinekit-Hal Circle CI stub"
+      - checkout:
+          path: machinekit-hal
+      - run:
+          name: Install Python ruamel.yaml and sh
+          command: pip install ruamel.yaml sh
+      - run:
+          name: Generate Machinekit-HAL build config
+          command: |
+            ./machinekit-hal/.circleci/generateconfig.py generated_config.yml
+      - continuation/continue:
+          configuration_path: generated_config.yml
+
+workflows:
+  setupMachinekitHAL:
+    jobs:
+      - setup-build:
+          name: preparatoryJob

--- a/.circleci/generateconfig.py
+++ b/.circleci/generateconfig.py
@@ -1,0 +1,262 @@
+#!/bin/env python3
+import argparse
+import pathlib
+import json
+import os
+
+from ruamel.yaml import YAML
+
+import importlib.util
+spec = importlib.util.spec_from_file_location(
+    "machinekit_hal_script_helpers",
+    "{0}/support/python/machinekit_hal_script_helpers.py".format(
+        os.path.realpath(
+            "{0}/..".format(os.path.dirname(os.path.abspath(__file__)))
+        )))
+helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helpers)
+
+
+class MachinekitHALCircleCIGenerator:
+    TEST_ARCHITECTURES_TO_EXECUTORS = {
+        'amd64': 'basic-amd64',
+        'arm64': 'basic-arm64',
+    }
+
+    DEBIAN_DISTRO_SETTINGS = pathlib.Path(
+        'debian/buildsystem/debian-distro-settings.json'
+    )
+
+    CIRCLE_CI_BASE = pathlib.Path('.circleci/base.yaml')
+
+    def __init__(self, generate_config_path: pathlib.Path, test_architectures: list):
+        """The MachinekitHALCircleCIGenerator's contructor. The execution is dependent
+        on the '.circleci/base.yaml' and 'debian/buildsystem/debian-distro-settings.json'
+        files and will error out of these files do no contain valid information
+        or are in othervise invalid state (for example use unknown schema)
+
+        Args:
+            generate_config_path (pathlib.Path): Valid path to as of yet non-existing file
+                                                 where the Circle CI configuration will be
+                                                 generated
+            test_architectures (list): Real hardware executor architectures on which the
+                                       compilation and testing will be performed
+
+        Raises:
+            RuntimeError: Raised when the passed architecture arguments are incorrect
+        """
+        self.output_path = generate_config_path
+
+        if not isinstance(generate_config_path, pathlib.Path):
+            generate_config_path = pathlib.Path(generate_config_path)
+        if not isinstance(test_architectures, list):
+            test_architectures = list(test_architectures)
+
+        if not set(test_architectures).issubset(set(self.TEST_ARCHITECTURES_TO_EXECUTORS.keys())):
+            raise RuntimeError(
+                f'Disallowed testing architectures {test_architectures}')
+        self.test_architectures = test_architectures
+
+        repository_root = helpers.NormalizeMachinekitHALPath(__file__)()
+
+        configuration_file = repository_root / self.DEBIAN_DISTRO_SETTINGS
+        circleci_base_file = repository_root / self.CIRCLE_CI_BASE
+
+        self.yaml = YAML(typ='safe')
+        self.yaml.default_flow_style = False
+
+        with open(circleci_base_file, 'r') as file:
+            self.circleci_base = self.yaml.load(file)
+
+        with open(configuration_file, 'r') as file:
+            configurations = json.load(file)
+
+        self.allowed_configurations = configurations.get(
+            'allowedCombinations', list())
+        self.os_versions = configurations.get('osVersions', list())
+
+        self.package_build_configurations = list()
+        self.package_test_configurations = list()
+        self.build_tree_test_suites_configurations = list()
+
+    def generate_builder_configurations(self):
+        """Generate the build and testing configuration for Circle CI workflow
+
+        Raises:
+            RuntimeError: Raised when the input data from 'debian/buildsystem/ \
+                          debian-distro-settings.json' is not valid
+        """
+        os_lut = dict()
+        self.build_configurations = list()
+
+        for os in self.os_versions:
+            release_number = os.get('releaseNumber', None)
+
+            if release_number is None:
+                raise RuntimeError(
+                    f'Invalid settings: Release Number: {release_number} in {os}')
+
+            os_lut[release_number] = os
+
+        for configuration in self.allowed_configurations:
+            target_architecture = configuration.get('architecture', None)
+            os_version_number = configuration.get('osVersionNumber', None)
+
+            if not (target_architecture and os_version_number):
+                raise RuntimeError(f'Invalid settings: Architecture: {target_architecture}, '
+                                   f'osVersionNumber: {os_version_number} in {configuration}')
+
+            distribution_name = os_lut.get(os_version_number, None).get(
+                'distributionID', None)
+            distribution_codename = os_lut.get(
+                os_version_number, None).get('distributionCodename', None)
+
+            if not (distribution_name and distribution_codename):
+                raise RuntimeError(f'Invalid settings: Distribution: {distribution_name}, '
+                                   f'Codename: {distribution_codename} in {os_lut}')
+
+            distribution_name = distribution_name.lower()
+            distribution_version = str(os_version_number).lower()
+            distribution_codename = distribution_codename.lower()
+            target_architecture = target_architecture.lower()
+
+            for architecture in self.test_architectures:
+                executor = self.TEST_ARCHITECTURES_TO_EXECUTORS[architecture]
+
+                self.package_build_configurations.append(
+                    {
+                        'buildMachinekitHALPackages': dict(
+                            name=f'buildMachinekitHALPackages-{distribution_name}-{distribution_codename}-{target_architecture}',
+                            distribution_name=distribution_name,
+                            distribution_version=distribution_version,
+                            target_architecture=target_architecture,
+                            executor=executor,
+                        )
+                    }
+                )
+
+                if architecture == target_architecture:
+                    # Jobs which will run the Runtest testsuite installed from Deb packages in
+                    # Docker containers
+                    self.package_test_configurations.append(
+                        {
+                            'testMachinekitHALPackages': dict(
+                                name=f'testMachinekitHALPackages-{distribution_name}-{distribution_codename}-{target_architecture}',
+                                requires=[
+                                    f'buildMachinekitHALPackages-{distribution_name}-{distribution_codename}-{target_architecture}'],
+                                distribution_name=distribution_name,
+                                distribution_version=distribution_version,
+                                target_architecture=target_architecture,
+                                executor=executor,
+                            )
+                        }
+                    )
+
+                    # Jobs which will run the testsuites (PyTests and Runtests)
+                    # from the CMake build tree
+                    self.build_tree_test_suites_configurations.append(
+                        {
+                            'buildDebianVersionAndRunTestsuites': dict(
+                                name=f'buildDebianVersionAndRunTestsuites-{distribution_name}-{distribution_codename}-{target_architecture}',
+                                distribution_name=distribution_name,
+                                distribution_version=distribution_version,
+                                target_architecture=target_architecture,
+                                executor=executor,
+                            )
+                        }
+                    )
+
+    def generate_circle_ci_config(self):
+        """Writes the henerated Circle CI workflow configuration to the YAML file
+        path specified in the constructor
+        """
+        configuration = dict(self.circleci_base)
+        workflow = {
+            'workflows': {
+                'buildMachinekitHAL': {
+                    'jobs': self.package_build_configurations +
+                    self.package_test_configurations +
+                    self.build_tree_test_suites_configurations
+                }
+            }
+        }
+
+        final = configuration | workflow
+
+        with open(self.output_path, 'w') as file:
+            self.yaml.dump(final, file)
+
+
+def main(args):
+    generator = MachinekitHALCircleCIGenerator(
+        args.output_path, args.test_architectures
+    )
+
+    generator.generate_builder_configurations()
+    generator.generate_circle_ci_config()
+
+
+class StoreValidYAMLPath(argparse.Action):
+    """Ad-hoc Argparser Action to check validity of YAML path specification
+    and create needed directory structure in advance
+    """
+
+    def test_path(self, path: str) -> pathlib.Path:
+        try:
+            yaml_path = pathlib.Path(path).resolve(strict=False)
+
+            if yaml_path.suffix not in ['.yaml', '.yml']:
+                raise argparse.ArgumentError(self,
+                                             f'Path {path} does not have valid YAML extension')
+
+            yaml_path.parent.mkdir(parents=True, exist_ok=True)
+            if yaml_path.exists():
+                raise argparse.ArgumentError(self,
+                                             f'Path {yaml_path} already exists. Not going to overwite!')
+            return yaml_path
+        except Exception as e:
+            raise argparse.ArgumentError(self,
+                                         f'Path {path} checking caused unknown error: {e}')
+
+        if not os.path.isdir(path):
+            raise argparse.ArgumentError(self,
+                                         "Path {} does not exist.".format(path))
+        if not os.access(path, os.W_OK):
+            raise argparse.ArgumentError(self,
+                                         "Path {} cannot be written to.".format(path))
+        return os.path.realpath(os.path.abspath(path.rstrip(os.sep)))
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if type(values) == list:
+            paths = map(self.test_path, values)
+        else:
+            paths = self.test_path(values)
+
+        setattr(namespace, self.dest, paths)
+
+
+if __name__ == "__main__":
+    """ This is executed when run from the command line """
+    parser = argparse.ArgumentParser(
+        description="Dynamic configuration tool for Circle CI Machinekit-HAL")
+
+    # Mandatory argument for path to Machinekit-HAL repository
+    parser.add_argument(action=StoreValidYAMLPath,
+                        dest='output_path',
+                        metavar='PATH',
+                        help="Path of YAML file with generated configuration for Circle CI")
+    # Voluntarily mandatory argument for selecting architectures which will be tested
+    parser.add_argument('-a',
+                        '--architecture',
+                        action='store',
+                        dest='test_architectures',
+                        nargs='*',
+                        metavar='ARCHITECTURE',
+                        choices=MachinekitHALCircleCIGenerator.TEST_ARCHITECTURES_TO_EXECUTORS.keys(),
+                        type=str.lower,
+                        default=['arm64'],
+                        help="Path of YAML file with generated configuration for Circle CI")
+
+    args = parser.parse_args()
+
+    main(args)

--- a/.github/workflows/debian-builder-workflow.yaml
+++ b/.github/workflows/debian-builder-workflow.yaml
@@ -387,7 +387,7 @@ jobs:
         run: |
           if [ "${{ needs.prepareState.outputs.BuildDockerImages }}" == "true" ]
           then
-            debian/buildcontainerimage.py -d ${IMAGE_NAME_PREFIX} \
+            debian/buildcontainerimage.py -r ${IMAGE_NAME_PREFIX} \
                                           ${DISTRIBUTION}         \
                                           ${VERSION}              \
                                           ${ARCHITECTURE}
@@ -517,12 +517,12 @@ jobs:
           ${{ matrix.osVersionCodename}}
         if: matrix.architecture == 'amd64'
         run: |
-          debian/buildcontainerimage.py -d ${IMAGE_NAME_PREFIX} \
+          debian/buildcontainerimage.py -r ${IMAGE_NAME_PREFIX} \
                                            ${DISTRIBUTION}      \
                                            ${VERSION}           \
                                            ${ARCHITECTURE}      \
                                         -t ${BUILD_TARGET}      \
-                                           ${IMAGE_NAME}
+                                        -d ${IMAGE_NAME}
         env:
           IMAGE_NAME_PREFIX: 'docker.pkg.github.com/${{ github.repository }}'
           DISTRIBUTION: ${{ matrix.osDistribution}}
@@ -602,7 +602,7 @@ jobs:
         run: |
           if [ "${{ needs.prepareState.outputs.BuildDockerImages }}" == "true" ]
           then
-            debian/buildcontainerimage.py -d ${IMAGE_NAME_PREFIX} \
+            debian/buildcontainerimage.py -r ${IMAGE_NAME_PREFIX} \
                                              ${DISTRIBUTION}      \
                                              ${VERSION}           \
                                              ${ARCHITECTURE}
@@ -690,7 +690,7 @@ jobs:
           Build the docker image for ${{ matrix.osDistribution }}
           ${{ matrix.osVersionCodename}}, ${{ matrix.architecture }} Builder
         run: |
-          debian/buildcontainerimage.py -d ${IMAGE_NAME_PREFIX} \
+          debian/buildcontainerimage.py -r ${IMAGE_NAME_PREFIX} \
                                            ${DISTRIBUTION}      \
                                            ${VERSION}           \
                                            ${ARCHITECTURE}

--- a/.github/workflows/debian-builder-workflow.yaml
+++ b/.github/workflows/debian-builder-workflow.yaml
@@ -538,13 +538,14 @@ jobs:
           run Runtests
         if: matrix.architecture == 'amd64'
         run: |
-          docker run --tty --rm -u "$(id -u):$(id -g)" \
+          docker run --tty --rm -u "$(id -u):$(id -g)"  \
             -v "$(pwd):/home/machinekit/machinekit-hal" \
-            -w "/home/machinekit/machinekit-hal" \
-            ${DOCKER_IMAGE} \
+            -w "/home/machinekit/machinekit-hal"        \
+            --cap-add=sys_nice                          \
+            ${DOCKER_IMAGE}                             \
             /bin/bash -c "
             #!/bin/bash -e
-            sudo apt-get install -y \
+            sudo apt-get install -y                 \
               /home/machinekit/machinekit-hal/*.deb
             echo "ANNOUNCE_IPV4=0" | sudo tee -a /etc/machinekit/hal/machinekit.ini
             echo "ANNOUNCE_IPV6=0" | sudo tee -a /etc/machinekit/hal/machinekit.ini

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 <img alt="Github Actions build status" src="https://img.shields.io/github/workflow/status/machinekit/machinekit-hal/Check the codebase for formatting and linting violations/master?style=for-the-badge&logo=github" />
 </a>
 
+<a href="https://app.circleci.com/pipelines/github/machinekit/machinekit-hal" target="_blank">
+<img alt="Circle CI build status" src="https://img.shields.io/circleci/build/github/machinekit/machinekit-hal?logoColor=circle&style=for-the-badge&logo=circleci" />
+</a>
+
 <a href="https://cloud.drone.io/machinekit/machinekit-hal" target="_blank">
 <img alt="Drone Cloud build status" src="https://img.shields.io/drone/build/machinekit/machinekit-hal/master?style=for-the-badge&logo=drone" />
 </a>

--- a/support/python/machinekit_hal_script_helpers.py
+++ b/support/python/machinekit_hal_script_helpers.py
@@ -57,6 +57,10 @@ class NormalizeMachinekitHALPath():
     def __init__(self, path: Union[pathlib.Path, str]):
         self.path = path if isinstance(
             path, pathlib.Path) else pathlib.Path(path)
+
+        if self.path.is_file():
+            self.path = self.path.parent
+
         self.root_path: pathlib.Path = None
 
     def version_file_valid(self) -> bool:


### PR DESCRIPTION
This pull request implements following functionality:

- Adds a Circle CI service to the Machinekit-HAL release workings
- Implements a `arm64` based _Continuous Integration_ logic closely based on the Github Actions' `build-debian-workflow` one (building, cross-building, testing)
- Uses the _Virtual Machine_  `arm64` based executors and the testing Docker container are started with the `sys_nice` capabilities (the GA workflow also changed to not use the `--privileged` flag anymore), this should solve the `threads.0` issue for now what is not possible in Drone Cloud
- Adds the `pru-assembler` Debian packages for Debian and Ubuntu, architectures `arm64`, `armhf` and `i386` to the Machinekit dependencies Cloudsmith repository (I forgot to do it when publishing the CMake changes and that probably caused grief to people wanting to build the BBB/BBAI versions directly on the SBCs.)