### PR TITLE
Fix build and mksocfpga

### DIFF
--- a/debian/buildsystem/Dockerfile
+++ b/debian/buildsystem/Dockerfile
@@ -118,11 +118,18 @@ RUN apt-get update &&       \
     apt-get clean;
 
 # Kitware is publishing pre-built binaries only for amd64 and arm64 architectures!
-RUN curl -1vLf                                                                                                      \
-    $(curl -s https://api.github.com/repos/kitware/cmake/releases/latest |                                          \
-        jq -r --arg FILE "cmake-\d{1,}\.\d{1,}\.\d{1,}(-.{1,})?-linux-$(dpkg-architecture -qDEB_BUILD_GNU_CPU)\.sh" \
-        '.assets | .[] | select(.name? | match($FILE)) | .browser_download_url')                                    \
-        --output /tmp/cmake.sh &&                                                                                   \
+RUN curl \
+    --connect-timeout 30 \
+    --max-time 30 \
+    --retry 30 \
+    --retry-delay 5 \
+    --retry-max-time 40 \
+    https://api.github.com/repos/kitware/cmake/releases/latest --output /tmp/parsefile --silent
+
+RUN curl -1vLf \
+    $( jq -r --arg FILE "cmake-\d{1,}\.\d{1,}\.\d{1,}(-.{1,})?-linux-$(dpkg-architecture -qDEB_BUILD_GNU_CPU)\.sh" \
+        '.assets | .[] | select(.name? | match($FILE)) | .browser_download_url' /tmp/parsefile) \
+        --output /tmp/cmake.sh && \
     bash /tmp/cmake.sh --skip-license --prefix=/usr/local
 
 # Python 3.9 has --upgrade-deps, but lower versions need manual action

--- a/debian/buildsystem/debian-distro-settings.json
+++ b/debian/buildsystem/debian-distro-settings.json
@@ -17,12 +17,6 @@
       "distributionCodename": "Focal",
       "baseImage": "ubuntu:focal",
       "releaseNumber": 20.04
-    },
-    {
-      "distributionID": "Ubuntu",
-      "distributionCodename": "Hirsute",
-      "baseImage": "ubuntu:hirsute",
-      "releaseNumber": 21.04
     }
   ],
   "allowedCombinations": [
@@ -47,10 +41,6 @@
       "architecture": "amd64"
     },
     {
-      "osVersionNumber": 21.04,
-      "architecture": "amd64"
-    },
-    {
       "osVersionNumber": 18.04,
       "architecture": "armhf"
     },
@@ -63,10 +53,6 @@
       "architecture": "armhf"
     },
     {
-      "osVersionNumber": 21.04,
-      "architecture": "armhf"
-    },
-    {
       "osVersionNumber": 18.04,
       "architecture": "arm64"
     },
@@ -76,10 +62,6 @@
     },
     {
       "osVersionNumber": 20.04,
-      "architecture": "arm64"
-    },
-    {
-      "osVersionNumber": 21.04,
       "architecture": "arm64"
     }
   ],

--- a/src/modules/managed/drivers/hostmot2/hostmot2_core/include/hostmot2/hostmot2.h
+++ b/src/modules/managed/drivers/hostmot2/hostmot2_core/include/hostmot2/hostmot2.h
@@ -38,7 +38,7 @@
 #include "hostmot2-lowlevel.h"
 
 #ifndef FIRMWARE_NAME_MAX
-    #define FIRMWARE_NAME_MAX  30
+    #define FIRMWARE_NAME_MAX  62
 #endif
 
 #define HM2_VERSION "0.15"


### PR DESCRIPTION
Make the Builder build packages again and make Mksocfpga device tree overlay firmware load work again.