### PR TITLE
hm2/encoder: fix hal_pin access

### DIFF
--- a/src/modules/managed/drivers/hostmot2/hostmot2_core/src/encoder.c
+++ b/src/modules/managed/drivers/hostmot2/hostmot2_core/src/encoder.c
@@ -108,7 +108,7 @@ static void hm2_encoder_update_control_register(hostmot2_t *hm2,
         );
 
         do_flag(
-            &hm2->encoder.control_reg[i],
+            &encoder->control_reg[i],
             *e->hal.pin.index_mode,
             HM2_ENCODER_INDEX_MODE
         );


### PR DESCRIPTION
Fixes segfault when using hostmot2 encoders.